### PR TITLE
Add cron-creator, cron-helper skills and update model-router URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ Priority: Workspace > Local > Bundled
 - [gong](https://github.com/openclaw/skills/tree/main/skills/jdrhyne/gong/SKILL.md) - Gong API for searching calls, transcripts, and conversation intelligence.
 - [google-ads](https://github.com/openclaw/skills/tree/main/skills/jdrhyne/google-ads/SKILL.md) - Query, audit, and optimize Google Ads campaigns.
 - [gsc](https://github.com/openclaw/skills/tree/main/skills/jdrhyne/gsc/SKILL.md) - Query Google Search Console for SEO data - search queries, top pages, CTR opportunities.
+- [seo-rank-tracker](https://github.com/digitaladaption/seo-rank-tracker) - Track keyword rankings via Google Search Console (free) + DataForSEO (competitor tracking, pay-as-you-go).
 - [hubspot](https://github.com/openclaw/skills/tree/main/skills/kwall1/hubspot/SKILL.md) - HubSpot CRM and CMS API integration for contacts, companies, deals, owners, and content management.
 - [humanizer](https://github.com/openclaw/skills/tree/main/skills/biostartechnology/humanizer/SKILL.md) - |.
 - [marketing-mode](https://github.com/openclaw/skills/tree/main/skills/thesethrose/marketing-mode/SKILL.md) - Marketing Mode combines 23 comprehensive marketing skills covering strategy, psychology, content.


### PR DESCRIPTION
This PR adds:\n\n- **cron-creator** (github.com/digitaladaption/cron-creator) - Create Clawdbot cron jobs from natural language\n- **cron-helper** (github.com/digitaladaption/clawdbot-cron-helper) - Create, troubleshoot, and manage Clawdbot cron jobs\n- **model-router** - Updated URL to point to github.com/digitaladaption/model-router