### PR TITLE
Add PolyClaw to Finance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Priority: Workspace > Local > Bundled
 - [Marketing & Sales](#marketing--sales) (42)
 - [Productivity & Tasks](#productivity--tasks) (41)
 - [AI & LLMs](#ai--llms) (38)
-- [Finance](#finance) (29)
+- [Finance](#finance) (30)
 - [Media & Streaming](#media--streaming) (29)
 - [Notes & PKM](#notes--pkm) (44)
 - [iOS & macOS Development](#ios--macos-development) (13)
@@ -549,6 +549,7 @@ Priority: Workspace > Local > Bundled
 - [refund-radar](https://github.com/openclaw/skills/tree/main/skills/andreolf/refund-radar/SKILL.md) - Scan bank statements for recurring charges and draft refund requests.
 - [expense-tracker-pro](https://github.com/openclaw/skills/tree/main/skills/jhillin8/expense-tracker-pro/SKILL.md) - Track expenses via natural language with budget summaries.
 - [financial-market-analysis](https://github.com/openclaw/skills/tree/main/skills/seyhunak/financial-market-analysis/SKILL.md) - Stock and market sentiment analysis via Yahoo Finance.
+- [polyclaw](https://github.com/chainstacklabs/polyclaw) - Trade on Polymarket via split + CLOB execution. Browse markets, track positions with P&L, discover hedges via LLM.
 
 </details>
 


### PR DESCRIPTION
## Summary

Adding [PolyClaw](https://github.com/chainstacklabs/polyclaw) to the Finance section.

**PolyClaw** is an OpenClaw skill for Polymarket trading with order execution and LLM-powered hedge discovery.

### Features
- Trade on Polymarket via split + CLOB execution on Polygon
- Browse markets (trending, search, details)
- Track positions with live P&L
- Discover hedges via LLM contrapositive logic analysis

### Links
- GitHub: https://github.com/chainstacklabs/polyclaw
- ClawHub: https://clawhub.ai/skills/polyclaw
- Video: https://www.youtube.com/watch?v=s_uP802NVTE

### Notes
- Published on ClawHub v1.0.0
- MIT licensed
- Based on [polymarket-alpha-bot](https://github.com/chainstacklabs/polymarket-alpha-bot) by Chainstack