### PR TITLE
Add GitClassic skill to Git & GitHub section

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Priority: Workspace > Local > Bundled
 - [deepwiki](https://github.com/openclaw/skills/tree/main/skills/arun-8687/deepwiki/SKILL.md) - Query the DeepWiki MCP server for GitHub repository documentation, wiki structure.
 - [deepwork-tracker](https://github.com/openclaw/skills/tree/main/skills/adunne09/deepwork-tracker/SKILL.md) - Track deep work sessions locally (start/stop/status)
 - [deploy-agent](https://github.com/openclaw/skills/tree/main/skills/sherajdev/deploy-agent/SKILL.md) - Multi-step deployment agent for full-stack apps.
+* [gitclassic](https://gitclassic.com) - Fast, no-JS GitHub browser for AI agents. Browse repos, read files, view READMEs instantly. PRO adds private repo access.
 - [github](https://github.com/openclaw/skills/tree/main/skills/steipete/github/SKILL.md) - Interact with GitHub using the `gh` CLI.
 - [github-pr](https://github.com/openclaw/skills/tree/main/skills/dbhurley/github-pr/SKILL.md) - Fetch, preview, merge, and test GitHub PRs locally.
 - [gitload](https://github.com/openclaw/skills/tree/main/skills/waldekmastykarz/gitload/SKILL.md) - Download files or folders from GitHub without cloning the entire repo.


### PR DESCRIPTION
Adding GitClassic to the Git & GitHub section.

GitClassic is a fast, read-only GitHub browser with no JavaScript — perfect for AI agents that need to browse repos without dealing with GitHub's heavy client-side rendering.
Features

- Sub-500ms page loads (server-rendered HTML)
- No JavaScript required — clean, parseable HTML for agents
- Browse repos, read files, view READMEs
- Search users, orgs, and repositories
- PRO tier adds private repo access via GitHub OAuth

Links

- Website: https://gitclassic.com/
- Example: https://gitclassic.com/facebook/react

Notes

- Live for 2 weeks with 250k+ page views
- MIT licensed