### PR TITLE
Add Fal.ai to the Image & Video Generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ Priority: Workspace > Local > Bundled
 - [gifhorse](https://github.com/openclaw/skills/tree/main/skills/coyote-git/gifhorse/SKILL.md) - Search video dialogue and create reaction GIFs with subtitles.
 - [superdesign](https://github.com/openclaw/skills/tree/main/skills/mpociot/superdesign/SKILL.md) - Expert frontend design guidelines for modern UIs.
 - [comfyui](https://github.com/openclaw/skills/tree/main/skills/xtopher86/comfyui-request/SKILL.md) - Send workflow requests to ComfyUI and get image results.
+- [fal-ai](https://github.com/openclaw/skills/tree/main/skills/agmmnn/fal-ai/SKILL.md) - Generate images, videos and audio using Fal.ai's generative media API.
 
 </details>
 


### PR DESCRIPTION
## Summary

Adding [fal-api](https://github.com/openclaw/skills/tree/main/skills/agmmnn/fal-ai/SKILL.md) to the Image & Video Generation section.

fal-api is an OpenClaw skill for fal.ai's generative media platform with support for 600+ AI models including image, video, and audio generation.

## Features

- Generate images with FLUX, Stable Diffusion, and Recraft models
- Create videos with MiniMax and WAN models
- Transcribe audio with Whisper
- Queue-based async API with stdlib-only dependencies
- Support for all 600+ fal.ai models via direct endpoint usage
- Configurable via environment variables or clawdbot config

## Links

- **ClawHub**: https://www.clawhub.ai/agmmnn/fal-ai
- **GitHub**: [agmmnn/fal-api-skill](https://github.com/agmmnn/fal-api-skill)

## Notes

- Version: 0.1.0
- No external dependencies
- Requires `FAL_KEY` environment variable