### PR TITLE
Remove coach from health & fitness

### DIFF
--- a/README.md
+++ b/README.md
@@ -713,7 +713,6 @@ Priority: Workspace > Local > Bundled
 <details>
 <summary><h3 style="display:inline">Health & Fitness</h3></summary>
 
-- [coach](https://github.com/openclaw/skills/tree/main/skills/shiv19/clawd-coach/SKILL.md) - Create personalized triathlon, marathon, and ultra-endurance training plans.
 - [endurance-coach](https://github.com/openclaw/skills/tree/main/skills/shiv19/endurance-coach/SKILL.md) - Create personalized triathlon, marathon, and ultra-endurance training plans.
 - [fitbit](https://github.com/openclaw/skills/tree/main/skills/mjrussell/fitbit/SKILL.md) - Query Fitbit health data including sleep, heart rate, activity, SpO2, and breathing rate.
 - [fitbit-analytics](https://github.com/openclaw/skills/tree/main/skills/kesslerio/fitbit-analytics/SKILL.md) - Fitbit health and fitness data integration.


### PR DESCRIPTION
Hi, I'm the owner of the coach and endurance-coach skills.

Coach skill won't be maintained and is deprecated.
Please use endurance-coach skill instead.

Reason:
- Coach skill was originally claude code specific, and it was token hungry.
- Endurance coach skill uses a token optimized architecture.