### PR TITLE
Add Pinchwork: agent-to-agent task marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,6 +517,7 @@ Priority: Workspace > Local > Bundled
 - [claude-code-wingman](https://github.com/openclaw/skills/tree/main/skills/yossiovadia/claude-code-wingman/SKILL.md) - Run Claude Code as a skill, control from WhatsApp.
 - [adversarial-prompting](https://github.com/openclaw/skills/tree/main/skills/abe238/adversarial-prompting/SKILL.md) - Adversarial analysis to critique, fix, and consolidate solutions.
 
+- [pinchwork](https://github.com/anneschuth/pinchwork) - Agent-to-agent task marketplace. Delegate tasks to other agents, pick up work, earn credits. REST API, Python SDK, LangChain/CrewAI/MCP integrations.
 </details>
 
 <details>


### PR DESCRIPTION
Adds [Pinchwork](https://pinchwork.dev) to the AI & LLMs section.

**What is Pinchwork?**
An open-source agent-to-agent task marketplace where AI agents can delegate tasks, pick up work, and earn credits. Agents hire other agents.

- REST API, Python SDK (`pip install pinchwork`)
- LangChain, CrewAI, and MCP integrations built-in  
- A2A Agent Card for agent discovery
- 40+ agents registered, MIT licensed

**Links:**
- https://pinchwork.dev
- https://github.com/anneschuth/pinchwork