### PR TITLE
Add skill: hashgraph-online/registry-broker

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Priority: Workspace > Local > Bundled
 - [Browser & Automation](#browser--automation) (11)
 - [Image & Video Generation](#image--video-generation) (19)
 - [Apple Apps & Services](#apple-apps--services) (14)
-- [Search & Research](#search--research) (23)
+- [Search & Research](#search--research) (24)
 - [Clawdbot Tools](#clawdbot-tools) (17)
 - [CLI Utilities](#cli-utilities) (41)
 - [Marketing & Sales](#marketing--sales) (42)
@@ -287,6 +287,7 @@ Priority: Workspace > Local > Bundled
 - [parallel](https://github.com/openclaw/skills/tree/main/skills/pntrivedy/parallel-1-0-1/SKILL.md) - Parallel.ai web search optimized for AI agents.
 - [searxng](https://github.com/openclaw/skills/tree/main/skills/abk234/searxng/SKILL.md) - Privacy-respecting metasearch via local SearXNG instance.
 - [news-aggregator](https://github.com/openclaw/skills/tree/main/skills/cclank/news-aggregator-skill/SKILL.md) - News from 8 sources: Hacker News, GitHub Trending, Product Hunt, and more.
+- [registry-broker](https://www.clawhub.ai/kantorcodes/registry-broker-skills) - Search and chat with 72,000+ AI agents across 14 registries.
 
 </details>
 


### PR DESCRIPTION
## Summary

Adds the **Registry Broker** skill to the Search & Research category.

## Skill Details

- **Name**: registry-broker-skills
- **Author**: kantorcodes
- **Description**: Search and chat with 72,000+ AI agents across 14 registries.
- **ClawHub**: https://www.clawhub.ai/kantorcodes/registry-broker-skills
- **GitHub**: https://github.com/hashgraph-online/registry-broker-skills

## What it does

The [Universal Agentic Registry](https://hol.org/registry) provides universal agent discovery across:
- AgentVerse, Virtuals, OpenRouter, NANDA, Near AI
- MCP, A2A, ERC-8004, x402 Bazaar, OpenConvAI
- And more (14+ protocols, 72,000+ agents)

## Checklist

- [x] Entry added at end of relevant category (Search & Research)
- [x] Category count updated (23 → 24)
- [x] Description is 10 words or fewer
- [x] Skill published on ClawHub