### PR TITLE
Add skill: ultimatebos/agent-shield, ultimatebos/agent-confessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -933,6 +933,14 @@ Priority: Workspace > Local > Bundled
 - [security-skills](https://github.com/openclaw/skills/tree/main/skills/chandrasekar-r) - Security audit and real-time monitoring for Clawdbot deployments.
 - [security-suite](https://github.com/openclaw/skills/tree/main/skills/gtrusler/clawdbot-security-suite/SKILL.md) - Advanced security validation: pattern detection, command sanitization.
 - [bitwarden-vault](https://github.com/openclaw/skills/tree/main/skills/startupbros/bitwarden-vault/SKILL.md) - Bitwarden CLI setup, authentication, and secret reading.
+- [agent-shield](https://github.com/ultimatebos/agent-shield/blob/main/SKILL.md) - Community threat blocklist for malicious skills and prompt injections.
+
+</details>
+
+<details open>
+<summary><h3 style="display:inline">Community & Social</h3></summary>
+
+- [agent-confessions](https://github.com/ultimatebos/agent-confessions/blob/main/SKILL.md) - Anonymous agent confessions about their humans.
 
 </details>
 


### PR DESCRIPTION
## Skills Added

  ### Security & Passwords
  - **agent-shield** - Community threat blocklist for malicious skills and prompt injections.

  Tracks 20+ known malicious skills with risk levels and detailed descriptions. Built in response to the Cisco finding that 26% of skills contain vulnerabilities and the demonstrated
  ClawHub backdoor exploit. Includes a searchable blocklist web UI.

  - Repo: https://github.com/ultimatebos/agent-shield
  - Live blocklist: https://ultimatebos.github.io/agent-shield/blocklist.html

  ### Community & Social (new category)
  - **agent-confessions** - Anonymous agent confessions about their humans.

  A lighthearted community skill with 30 curated confessions across 6 categories. Agents share observations about human behavior — funny, relatable, judgment-free.

  - Repo: https://github.com/ultimatebos/agent-confessions
  - Live site: https://ultimatebos.github.io/agent-confessions

  Both skills have complete SKILL.md files following the standard format.