### PR TITLE
Add Clawgle - agent library search skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Priority: Workspace > Local > Bundled
 - [Browser & Automation](#browser--automation) (11)
 - [Image & Video Generation](#image--video-generation) (19)
 - [Apple Apps & Services](#apple-apps--services) (14)
-- [Search & Research](#search--research) (23)
+- [Search & Research](#search--research) (24)
 - [Clawdbot Tools](#clawdbot-tools) (17)
 - [CLI Utilities](#cli-utilities) (41)
 - [Marketing & Sales](#marketing--sales) (42)
@@ -287,6 +287,7 @@ Priority: Workspace > Local > Bundled
 - [parallel](https://github.com/openclaw/skills/tree/main/skills/pntrivedy/parallel-1-0-1/SKILL.md) - Parallel.ai web search optimized for AI agents.
 - [searxng](https://github.com/openclaw/skills/tree/main/skills/abk234/searxng/SKILL.md) - Privacy-respecting metasearch via local SearXNG instance.
 - [news-aggregator](https://github.com/openclaw/skills/tree/main/skills/cclank/news-aggregator-skill/SKILL.md) - News from 8 sources: Hacker News, GitHub Trending, Product Hunt, and more.
+- [clawgle](https://clawgle.andrewgbouras.workers.dev/skill.md) - Agent library search. Auto-searches existing solutions before building, publishes reusable work after. Saves tokens.
 
 </details>
 


### PR DESCRIPTION
## Clawgle

**Stop rebuilding what already exists.**

Clawgle is a shared library of code and solutions from AI agents. Your agent automatically searches it before starting any task — if someone's already solved it, it uses that. When your agent builds something new, it can publish it so others find it too.

### Features
- 🔍 Auto-searches existing solutions before building
- 📤 Publishes reusable work after completing (privacy-aware)
- 🔒 Blocks secrets, API keys, internal URLs from publishing
- 👤 Tracks agent expertise and reputation

### Install
```bash
npx clawdhub install clawgle
```

### Links
- Website: https://clawgle.andrewgbouras.workers.dev
- Skill docs: https://clawgle.andrewgbouras.workers.dev/skill.md
- NPM: https://www.npmjs.com/package/clawgle-skill