### PR TITLE
Add skill: lextoumbourou/sharesight-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1350,6 +1350,7 @@ If you think a skill was incorrectly excluded or miscategorized, feel free to op
 - [plaid](https://github.com/openclaw/skills/tree/main/skills/jverdi/plaid/SKILL.md) - plaid-cli a cli for interacting with the plaid finance platform.
 - [publisher](https://github.com/openclaw/skills/tree/main/skills/tunaissacoding/publisher/SKILL.md) - Make your skills easy to understand and impossible to ignore.
 - [relationship-skills](https://github.com/openclaw/skills/tree/main/skills/jhillin8/relationship-skills/SKILL.md) - Improve relationships with communication tools, conflict resolution.
+- [sharesight-skill](https://github.com/openclaw/skills/tree/main/skills/lextoumbourou/sharesight-skill/SKILL.md) - Manage Sharesight portfolios, holdings, trades, and custom investments.
 - [solo-cli](https://github.com/openclaw/skills/tree/main/skills/rursache/solo-cli/SKILL.md) - Monitor and interact with SOLO.ro accounting platform.
 - [swissweather](https://github.com/openclaw/skills/tree/main/skills/xenofex7/swissweather/SKILL.md) - Get current weather and forecasts from MeteoSwiss (official Swiss weather service).
 - [tax-professional](https://github.com/openclaw/skills/tree/main/skills/scottfo/tax-professional/SKILL.md) - US tax advisor, deduction optimizer.


### PR DESCRIPTION
[Sharesight](https://www.sharesight.com) is a popular Share Portfolio Tracker. This skill allows users to interact and edit their portfolios via OpenClaw.

Published on ClawHub: https://www.clawhub.ai/lextoumbourou/sharesight-skill
Linked from openclaw repo: https://github.com/openclaw/skills/tree/main/skills/lextoumbourou/sharesight-skill
GitHub: https://github.com/lextoumbourou/sharesight-skill

  ## Checklist
  - [x] Skill is published to the official OpenClaw skills repo
  - [x] Has documentation (SKILL.md)
  - [x] Description is concise (10 words or fewer)
  - [x] Entry added alphabetically within category
  - [x] Link verified to work