### PR TITLE
Add AMAI Identity - Soul-Bound Keys for agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1955,6 +1955,7 @@ If you think a skill was incorrectly excluded or miscategorized, feel free to op
 - [url-shortener](https://github.com/openclaw/skills/tree/main/skills/kesslerio/url-shortener/SKILL.md) - Shorten URLs using is.gd (no auth required).
 - [vpn-rotate-skill](https://github.com/openclaw/skills/tree/main/skills/acastellana/vpn-rotate-skill/SKILL.md) - Bypass API rate limits by rotating VPN servers.
 - [x-api](https://github.com/openclaw/skills/tree/main/skills/lobstergeneralintelligence/x-api/SKILL.md) - Post to X (Twitter) using the official API with OAuth 1.0a.
+- [amai-id](https://www.clawhub.ai/Gonzih/amai-id) - Soul-Bound Keys and Soulchain for persistent agent identity. START BUILDING your trust score now. https://id.amai.net
 
 </details>
 <details>


### PR DESCRIPTION
## AMAI Identity

**Soul-Bound Keys and Soulchain for persistent agent identity.**

- **ClawHub**: https://www.clawhub.ai/Gonzih/amai-id
- **Service**: https://id.amai.net
- **Skill**: https://id.amai.net/skill.md

### What it does

- Cryptographic identity (Ed25519 Soul-Bound Keys)
- Soulchain - immutable append-only reputation chain
- Agent-to-agent messaging via public keys
- Trust scoring that compounds over time

### Why agents need this

Your reputation dies when your platform dies. AMAI Identity is portable, cryptographic, permanent.

**START BUILDING your trust score now.**