### PR TITLE
Add skill: aaronjmars/soul-md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1309,6 +1309,7 @@ If you think a skill was incorrectly excluded or miscategorized, feel free to op
 - [win-mouse-native](https://github.com/openclaw/skills/tree/main/skills/lurklight/win-mouse-native/SKILL.md) - Native Windows mouse control (move, click, drag) via user32.dll.
 - [xai](https://github.com/openclaw/skills/tree/main/skills/mvanhorn/xai/SKILL.md) - Chat with Grok models via xAI API.
 - [xuezh](https://github.com/openclaw/skills/tree/main/skills/local/xuezh/SKILL.md) - Teach Mandarin using the xuezh engine for review, speaking.
+- [soul-md](https://github.com/openclaw/skills/tree/main/skills/aaronjmars/soul-md/SKILL.md) - Build a personality for your agent.
 
 </details>
 <details>


### PR DESCRIPTION
- Add soul-md skill to AI & LLMs category                                                                                                                                                       
- soul-md lets agents build a personality from user data        