### PR TITLE
Add samma-suit — 8 security governance layers for OpenClaw agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -3180,6 +3180,7 @@ If you think a skill was incorrectly excluded or miscategorized, feel free to op
 - [one-skill-to-rule-them-all](https://github.com/openclaw/skills/tree/main/skills/hichana/one-skill-to-rule-them-all/SKILL.md) - Adversarial security analysis skill
 - [openclaw-skills-security-checker](https://github.com/openclaw/skills/tree/main/skills/digitaladaption/openclaw-skills-security-checker/SKILL.md) - Security scanner
 - [pdauth](https://github.com/openclaw/skills/tree/main/skills/g9pedro/pdauth/SKILL.md) - Dynamic OAuth for AI agents via Pipedream.
+- [samma-suit](https://clawhub.ai/OneZeroEight-ai/samma-suit) - Add 8 security governance layers to your OpenClaw agent — budget controls, permissions, audit logging, kill switch, identity signing, skill vetting, and process isolation.
 - [secureclaw](https://github.com/openclaw/skills/tree/main/skills/alonx2/secureclaw/SKILL.md) - Community-driven security intelligence for AI agents.
 - [security-heuristics](https://github.com/openclaw/skills/tree/main/skills/luluf0x/security-heuristics/SKILL.md) - Mental checklist before installing ANY external
 - [security-sentinel](https://github.com/openclaw/skills/tree/main/skills/autogame-17/security-sentinel/SKILL.md) - Scan the workspace for security vulnerabilities


### PR DESCRIPTION
Adds [samma-suit](https://clawhub.ai/OneZeroEight-ai/samma-suit) to the skill directory.

Samma Suit is an open-source security framework that adds 8 governance layers to OpenClaw as lifecycle hooks:

- NIRVANA — Kill switch
- DHARMA — Permission enforcement
- SANGHA — Skill vetting with AST scanning
- KARMA — Per-agent budget controls
- BODHI — Process isolation and egress allowlists
- METTA — Ed25519 cryptographic signing
- SILA — Audit trail with cost tracking

Install: `openclaw plugins install samma-suit`
Verified compatible: `openclaw plugins doctor ✓`

Published on ClawHub: https://clawhub.ai/OneZeroEight-ai/samma-suit
GitHub: https://github.com/OneZeroEight-ai/samma-suit
Site: https://sammasuit.com