### PR TITLE
Update skill descriptions: jdrhyne/nudocs, nutrient-document-processing, nutrient-openclaw

### DIFF
--- a/README.md
+++ b/README.md
@@ -3073,9 +3073,9 @@ If you think a skill was incorrectly excluded or miscategorized, feel free to op
 - [mxe](https://github.com/openclaw/skills/tree/main/skills/tuanpmt/mxe/SKILL.md) - Convert Markdown files to PDF, DOCX, or HTML with advanced features.
 - [nano-pdf](https://github.com/openclaw/skills/tree/main/skills/steipete/nano-pdf/SKILL.md) - Edit PDFs with natural-language instructions using the nano-pdf CLI.
 - [nosi](https://github.com/openclaw/skills/tree/main/skills/billhao/nosi/SKILL.md) - Publish content to Nosi and get a shareable URL.
-- [nudocs](https://github.com/openclaw/skills/tree/main/skills/jdrhyne/nudocs/SKILL.md) - Upload, edit, and export documents via Nudocs.ai.
-- [nutrient-document-processing](https://github.com/openclaw/skills/tree/main/skills/jdrhyne/nutrient-document-processing/SKILL.md) - Document processing for OpenClaw
-- [nutrient-openclaw](https://github.com/openclaw/skills/tree/main/skills/jdrhyne/nutrient-openclaw/SKILL.md) - Document processing for OpenClaw — convert, extract, OCR
+- [nudocs](https://github.com/openclaw/skills/tree/main/skills/jdrhyne/nudocs/SKILL.md) - AI-native document editor — upload, edit, export via Nudocs.ai.
+- [nutrient-document-processing](https://github.com/openclaw/skills/tree/main/skills/jdrhyne/nutrient-document-processing/SKILL.md) - Convert, OCR, redact, sign PDFs via Nutrient DWS API.
+- [nutrient-openclaw](https://github.com/openclaw/skills/tree/main/skills/jdrhyne/nutrient-openclaw/SKILL.md) - Full PDF toolkit — OCR, redact, sign, extract, watermark.
 - [pdd](https://github.com/openclaw/skills/tree/main/skills/paulpete/pdd/SKILL.md) - Transforms a rough idea into a detailed design document with implementation.
 - [pdf-form-filler](https://github.com/openclaw/skills/tree/main/skills/raulsimpetru/pdf-form-filler/SKILL.md) - Fill PDF forms programmatically with text values
 - [pptx-creator](https://github.com/openclaw/skills/tree/main/skills/dbhurley/pptx-creator/SKILL.md) - Create professional PowerPoint presentations from outlines, data


### PR DESCRIPTION
## Summary

Updates descriptions for three Nutrient skills in the **PDF & Documents** category to better communicate their capabilities.

### Changes

| Skill | Before | After |
|-------|--------|-------|
| **nudocs** | Upload, edit, and export documents via Nudocs.ai. | AI-native document editor — upload, edit, export via Nudocs.ai. |
| **nutrient-document-processing** | Document processing for OpenClaw | Convert, OCR, redact, sign PDFs via Nutrient DWS API. |
| **nutrient-openclaw** | Document processing for OpenClaw — convert, extract, OCR | Full PDF toolkit — OCR, redact, sign, extract, watermark. |

### Why

The previous descriptions were generic ("Document processing for OpenClaw" appeared twice). The updated descriptions:
- Differentiate the three skills from each other
- List specific capabilities so users know what they're installing
- Stay within the 10-word guideline

All three skills are published in the [official OpenClaw skills repo](https://github.com/openclaw/skills/tree/main/skills/jdrhyne).