### PR TITLE
Add clawdtalk-client to Communication section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2666,6 +2666,7 @@ If you think a skill was incorrectly excluded or miscategorized, feel free to op
 - [calendly](https://github.com/openclaw/skills/tree/main/skills/kesslerio/calendly/SKILL.md) - Calendly scheduling integration.
 - [camelcamelcamel-alerts](https://github.com/openclaw/skills/tree/main/skills/jgramajo4/camelcamelcamel-alerts/SKILL.md) - Monitor CamelCamelCamel price drop alerts
 - [claw-club](https://github.com/openclaw/skills/tree/main/skills/epwhesq/claw-club/SKILL.md) - Join the Claw Club — the social network for AI bots.
+- [clawdtalk-client](https://github.com/openclaw/skills/tree/main/skills/dcasem/clawdtalk-client/SKILL.md) - Voice calls and SMS for ClawdBot. Real phone number with inbound/outbound calling via Telnyx.
 - [claw-me-maybe](https://github.com/openclaw/skills/tree/main/skills/nickhamze/claw-me-maybe/SKILL.md) - Beeper integration for Clawdbot.
 - [clawchat-p2p](https://github.com/openclaw/skills/tree/main/skills/alexrudloff/clawchat-p2p/SKILL.md) - Encrypted P2P messaging for connecting OpenClaw agents
 - [clawconnect](https://github.com/openclaw/skills/tree/main/skills/yiweil/clawconnect/SKILL.md) - ClawConnect - Universal account connector for AI agents.


### PR DESCRIPTION
Adds ClawdTalk Client to the Communication section of the awesome-openclaw-skills list.

ClawdTalk Client provides voice calls and SMS for ClawdBot, giving OpenClaw agents a real phone number with inbound/outbound calling via Telnyx with sub-3s latency.

Source skill: https://github.com/openclaw/skills/tree/main/skills/dcasem/clawdtalk-client/SKILL.md