### PR TITLE
Add skill: myvibe-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ If you think a skill was incorrectly excluded or miscategorized, feel free to op
 - [multi-coding-agent](https://github.com/openclaw/skills/tree/main/skills/kesslerio/multi-coding-agent/SKILL.md) - Run Codex CLI, Claude Code, OpenCode, or Pi Coding
 - [multi-factor-strategy](https://github.com/openclaw/skills/tree/main/skills/wumu2013/multi-factor-strategy/SKILL.md) - Guide users to create multi-factor stock
 - [mux-video](https://github.com/openclaw/skills/tree/main/skills/dktrn9ne/mux-video/SKILL.md) - Mux Video infrastructure skill for designing, ingesting
+- [myvibe-skills](https://github.com/ArcBlock/myvibe-skills) - Publish web projects to a permanent live URL with a single command. Auto-detects project type (Static, Vite, Next.js, Astro, Nuxt), builds if needed, and deploys in seconds with zero configuration.
 - [noir-developer](https://github.com/openclaw/skills/tree/main/skills/jp4g/noir-developer/SKILL.md) - Develop Noir (.nr) codebases.
 - [only-baby-skill](https://github.com/openclaw/skills/tree/main/skills/jacklandrin/only-baby-skill/SKILL.md) - Analyze contraction JSON and baby log JSON to assess
 - [ooze-agents](https://github.com/openclaw/skills/tree/main/skills/jschwerberg/ooze-agents/SKILL.md) - Visual identity that evolves with reputation - create and nurture


### PR DESCRIPTION
## New Skill

**Name:** myvibe-skills

**Description:** Publish web projects to a permanent live URL with a single command

**Category:** Development & Deployment

**Link:** https://github.com/ArcBlock/myvibe-skills

---

### What it does:
- One-command deployment: type `/myvibe:publish` and get a live URL in seconds
- Auto-detects project type (Static HTML, Vite, Next.js, Astro, Nuxt, Monorepo)
- Builds if needed (supports npm, pnpm, yarn, bun)
- Auto-generates metadata (title, description, tags) and cover screenshots
- Zero configuration required - no server setup, no DNS, no hosting decisions

### Installation:
```bash
npx skills add ArcBlock/myvibe-skills
```

**Author:** ArcBlock (https://github.com/ArcBlock)
**License:** Apache-2.0