### PR TITLE
Add Reepl - LinkedIn content creation and scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1681,6 +1681,7 @@ If you think a skill was incorrectly excluded or miscategorized, feel free to op
 - [reddit](https://github.com/openclaw/skills/tree/main/skills/theglove44/reddit/SKILL.md) - Browse, search, post.
 - [reddit-search](https://github.com/openclaw/skills/tree/main/skills/thesethrose/reddit-search/SKILL.md) - Search Reddit for subreddits and get information.
 - [referral-program](https://github.com/openclaw/skills/tree/main/skills/jchopard69/marketing-skills/references/referral-program/SKILL.md) - When the user wants
+- [reepl](https://github.com/reepl-io/skills) - AI-powered LinkedIn content creation, scheduling, and analytics. Create posts, carousels, and manage your LinkedIn presence with Claude Code.
 - [sales-toolkit](https://github.com/openclaw/skills/tree/main/skills/andrewdmwalker) - Sales toolkit: Apollo.io enrichment, Attio CRM,...
 - [salesforce-dx](https://github.com/openclaw/skills/tree/main/skills/rjmcgirr-pl/salesforce-dx/SKILL.md) - Query Salesforce data and manage sales pipelines
 - [schema-markup](https://github.com/openclaw/skills/tree/main/skills/jchopard69/marketing-skills/references/schema-markup/SKILL.md) - When the user wants to add, fix


### PR DESCRIPTION
## Summary

- Adds [Reepl](https://github.com/reepl-io/skills) to the **Marketing & Sales** section
- Reepl is an AI-powered LinkedIn content creation, scheduling, and analytics platform
- Supports creating posts, carousels, and managing LinkedIn presence with Claude Code

## Placement

Inserted in alphabetical order between `referral-program` and `sales-toolkit` in the Marketing & Sales category.