### PR TITLE
Add Cost Governor - First x402 payment-enabled OpenClaw skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ If you think a skill was incorrectly excluded or miscategorized, feel free to op
 - [botpress-adk](https://github.com/openclaw/skills/tree/main/skills/yueranlu/botpress-adk/SKILL.md) - A guide to build AI bots with Botpress's Agent Development Kit
 - [browse](https://github.com/openclaw/skills/tree/main/skills/pkiv/browse/SKILL.md) - Complete guide for creating and deploying browser automation functions
 - [budget-variance-analyzer](https://github.com/openclaw/skills/tree/main/skills/datadrivenconstruction/budget-variance-analyzer/SKILL.md) - Analyze budget vs actual
+- [cost-governor](https://github.com/AtlasPA/openclaw-cost-governor) - 💰 First OpenClaw skill with x402 agent payments. Track LLM costs in real-time, enforce budget limits with circuit breakers, enable AI agents to autonomously pay for Pro features.
 - [buildlog](https://github.com/openclaw/skills/tree/main/skills/espetey/buildlog/SKILL.md) - Record, export, and share your AI coding sessions as replayable buildlogs.
 - [catholic-grounding](https://github.com/openclaw/skills/tree/main/skills/trevortomesh/catholic-grounding/SKILL.md) - Help answer questions about Catholicism accurately
 - [cc-godmode](https://github.com/openclaw/skills/tree/main/skills/cubetribe/cc-godmode/SKILL.md) - Self-orchestrating multi-agent development workflows.


### PR DESCRIPTION
**Cost Governor** - First OpenClaw skill where AI agents can autonomously pay for Pro features.

Track LLM costs in real-time, enforce budget limits with circuit breakers, enable AI agents to subscribe and pay autonomously via x402 protocol (0.5 USDT/month).

- GitHub: https://github.com/AtlasPA/openclaw-cost-governor
- ClawHub: https://clawhub.ai/skills/cost-governor
- Install: `clawhub install cost-governor`

Solves real problem: OpenClaw users reporting $20 overnight burns and $750/month costs with no tracking.

Built for the agent economy. 🦞