### PR TITLE
Add skill: ajspig/honcho-setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1370,6 +1370,7 @@ If you think a skill was incorrectly excluded or miscategorized, feel free to op
 - [glin-profanity-mcp](https://github.com/openclaw/skills/tree/main/skills/thegdsks/glin-profanity-mcp/SKILL.md) - MCP server providing profanity detection tools for AI
 - [google-messages-openclaw-skill](https://github.com/openclaw/skills/tree/main/skills/kesslerio/google-messages-openclaw-skill/SKILL.md) - Send and receive SMS/RCS
 - [holyspiritos](https://github.com/openclaw/skills/tree/main/skills/maxsikorski/holyspiritos/SKILL.md) - > **The Foundational Moral Engine for OpenClaw**
+- [honcho-setup](https://github.com/openclaw/skills/tree/main/skills/ajspig/honcho-setup/SKILL.md) - Agent memory that learns across sessions.
 - [hzl](https://github.com/openclaw/skills/tree/main/skills/tmchow/hzl/SKILL.md) - OpenClaw's persistent task database.
 - [jarvis-skills](https://github.com/openclaw/skills/tree/main/skills/aly-joseph/jarvis-skills/SKILL.md) - The Robotic Control skill integrates OpenClaw for physical
 - [lark-integration](https://github.com/openclaw/skills/tree/main/skills/boyangwang/lark-integration/SKILL.md) - Connect Lark (Feishu) messaging to OpenClaw via webhook


### PR DESCRIPTION
## Summary

- Added [honcho-setup](https://github.com/openclaw/skills/tree/main/skills/ajspig/honcho-setup/SKILL.md) to the Clawdbot Tools section

## What is Honcho?

Honcho is a reasoning-powered memory layer for AI agents built by [Plastic Labs](https://plasticlabs.ai).

- **Continual learning** — every message triggers reasoning via Neuromancer, Honcho's custom model. Not just store-and-retrieve
- **Cross-session persistence** — agent memory that learns and improves over time
- **Single method call** — `get_context()` returns curated reasoning plus conversation history, ~200ms
- **Token efficient** — get the 10K tokens you need, not the 100K you don't. SOTA on LongMem, LoCoMo, and BEAM benchmarks
- **Model-agnostic** — works with OpenAI, Anthropic, or custom models

## Positioning

Added to **Clawdbot Tools** alongside other memory skills (`memory`, `git-notes-memory`, `triple-memory`, etc.), alphabetically between `holyspiritos` and `hzl`.

## Links

- [ClawHub](https://clawhub.ai/ajspig/honcho-setup)
- [GitHub (skill)](https://github.com/openclaw/skills/tree/main/skills/ajspig/honcho-setup/SKILL.md)
- [Honcho](https://honcho.dev)