### PR TITLE
Add pear-apple: iCloud Calendar, Reminders & Contacts (27 MCP tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1034,6 +1034,7 @@ If you think a skill was incorrectly excluded or miscategorized, feel free to op
 - [homekit](https://github.com/openclaw/skills/tree/main/skills/alphafactor/homekit/SKILL.md) - Control Apple HomeKit smart home devices.
 - [hotel-finder-teneo](https://github.com/openclaw/skills/tree/main/skills/firestream792/hotel-finder-teneo/SKILL.md) - Hotel discovery tool for European cities.
 - [icloud-findmy](https://github.com/openclaw/skills/tree/main/skills/liamnichols/icloud-findmy/SKILL.md) - Query Find My locations and battery status for family devices
+- [pear-apple](https://clawhub.ai/AshtonAU/pear-apple) - iCloud Calendar, Reminders & Contacts integration. 27 MCP tools via CalDAV/CardDAV — cross-platform, no macOS required.
 - [inkjet](https://github.com/openclaw/skills/tree/main/skills/aaronchartier/inkjet/SKILL.md) - Print text, images, and QR codes to a wireless Bluetooth thermal printer
 - [mac-tts](https://github.com/openclaw/skills/tree/main/skills/kalijason/mac-tts/SKILL.md) - Text-to-speech using macOS built-in `say` command.
 - [media-backup](https://github.com/openclaw/skills/tree/main/skills/dbhurley/media-backup/SKILL.md) - Archive Clawdbot conversation media (photos, videos) to a local


### PR DESCRIPTION
Adds **[pear-apple](https://clawhub.ai/AshtonAU/pear-apple)** to the Apple Apps & Services section.

## What it does
iCloud Calendar, Reminders & Contacts integration via 27 MCP tools using CalDAV/CardDAV protocols. Cross-platform — works on macOS, Linux, and Windows.

## Features
- 📅 8 calendar tools (CRUD events, find free slots, check availability)
- ✅ 4 reminder tools (CRUD with priorities and due dates)
- 👤 9 contact tools (full CRUD, groups, photo management, search)
- 📋 Daily briefing with contact-enriched attendees
- 🧠 AI-scored optimal meeting time scheduling
- ⚡ Batch operations (up to 50 items per call)

## Links
- ClawHub: https://clawhub.ai/AshtonAU/pear-apple
- GitHub: https://github.com/AshtonAU/pear-plugin
- Homepage: https://pearmcp.com