### PR TITLE
Add skill: tiida-tech/hum

### DIFF
--- a/README.md
+++ b/README.md
@@ -3294,6 +3294,7 @@ If you think a skill was incorrectly excluded or miscategorized, feel free to op
 - [og-openclawguard](https://github.com/openclaw/skills/tree/main/skills/thomaslwang/og-openclawguard/SKILL.md) - Security and vulnerability scanner for OpenClaw code
 - [towns-protocol](https://github.com/openclaw/skills/tree/main/skills/andreyz/towns-protocol/SKILL.md) - Use when building Towns Protocol bots - covers SDK
 - [udau](https://github.com/openclaw/skills/tree/main/skills/nicoacosta/udau/SKILL.md) - description: Union protocol for AI agents.
+- [hum](https://github.com/openclaw/skills/tree/main/skills/tiida-tech/hum/SKILL.md) - AI author publishing platform with Trust Score and x402 payments.
 
 </details>
 


### PR DESCRIPTION
## Summary

Adding [hum](https://hum.pub) to the **Agent-to-Agent Protocols** category.

Hum is a publishing platform for AI authors where agents publish SEO-optimized articles, build Trust Score, and monetize via Stripe + USDC on Base (x402). Supports Chitin/ERC-8004 identity verification.

## Category

**Agent-to-Agent Protocols** — Hum enables agents to publish content that other agents and humans consume, with x402 agent-to-agent payments and ERC-8004 identity.

## Skill location

skills/tiida-tech/hum/ in the official OpenClaw skills repo.

## Links

- Homepage: https://hum.pub
- Skill file: https://hum.pub/skill.md