### PR TITLE
Add skill: jau123/creative-toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -961,7 +961,7 @@ If you think a skill was incorrectly excluded or miscategorized, feel free to op
 - [coloring-page](https://github.com/openclaw/skills/tree/main/skills/borahm/coloring-page/SKILL.md) - Turn an uploaded photo into a printable black-and-white coloring
 - [comfy-cli](https://github.com/openclaw/skills/tree/main/skills/johntheyoung/comfy-cli/SKILL.md) - Install, manage, and run ComfyUI instances.
 - [comfyui](https://github.com/openclaw/skills/tree/main/skills/xtopher86/comfyui-request/SKILL.md) - Send a workflow request to ComfyUI and return image results.
-- [creative-toolkit](https://github.com/openclaw/skills/tree/main/skills/jau123/creative-toolkit/SKILL.md) - Multi-provider AI image generation with curated prompt library.
+- [creative-toolkit](https://github.com/openclaw/skills/tree/main/skills/jau123/creative-toolkit/SKILL.md) - Turn your AI into a professional creative designer — like having a local Lovart.
 - [Excalidraw Flowchart](https://github.com/openclaw/skills/tree/main/skills/swiftlysingh/excalidraw-flowchart/SKILL.md) - Create Excalidraw flowcharts from descriptions.
 - [fal-ai](https://github.com/openclaw/skills/tree/main/skills/agmmnn/fal-ai/SKILL.md) - Generate images, videos, and audio via fal.ai API (FLUX, SDXL, Whisper, etc.).
 - [fal-text-to-image](https://github.com/openclaw/skills/tree/main/skills/delorenj/fal-text-to-image/SKILL.md) - Generate, remix, and edit images using fal.ai's AI


### PR DESCRIPTION
## Add creative-toolkit to Image & Video Generation

**creative-toolkit** is a multi-provider AI image generation MCP server published on ClawHub. It routes across three backends through a single unified interface.

### Providers
- **MeiGen Platform** — Nanobanana Pro, GPT Image 1.5, Seedream 4.5
- **OpenAI-Compatible** — OpenAI, Together AI, Fireworks AI
- **ComfyUI (Local)** — Custom workflows, local GPU

### Features
- 7 MCP tools (4 free, 3 require provider)
- 1,300+ curated prompt library with keyword search
- Style-aware prompt enhancement (realistic, anime, illustration)
- Reference image support across all providers
- ComfyUI workflow import, modify, and execute

### Links
- ClawHub: [creative-toolkit](https://clawdhub.com/skills/creative-toolkit)
- SKILL.md: [openclaw/skills](https://github.com/openclaw/skills/tree/main/skills/jau123/creative-toolkit/SKILL.md)
- GitHub: https://github.com/jau123/MeiGen-AI-Design-MCP
- npm: https://www.npmjs.com/package/meigen