### PR TITLE
Add skill: cosformula/douban-sync-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -2203,6 +2203,7 @@ If you think a skill was incorrectly excluded or miscategorized, feel free to op
 - [thingsboard-skill](https://github.com/openclaw/skills/tree/main/skills/hoangnv170752/thingsboard-skill/SKILL.md) - Manage ThingsBoard devices, dashboards, telemetry
 - [umea-data](https://github.com/openclaw/skills/tree/main/skills/simskii/umea-data/SKILL.md) - Query open data from Umeå kommun about locations, facilities
 - [yahoo-data-fetcher](https://github.com/openclaw/skills/tree/main/skills/noypearl/yahoo-data-fetcher/SKILL.md) - Fetch real-time stock quotes from Yahoo Finance.
+- [douban-sync-skill](https://github.com/openclaw/skills/tree/main/skills/cosformula/douban-sync-skill/SKILL.md) - Export and sync Douban (豆瓣) book/movie/music/game collections.
 
 </details>
 


### PR DESCRIPTION
Adds douban-sync-skill to Data & Analytics category.

- **Skill**: [douban-sync-skill](https://github.com/openclaw/skills/tree/main/skills/cosformula/douban-sync-skill/SKILL.md)
- **Description**: Export and sync Douban (豆瓣) book/movie/music/game collections to CSV
- **Published on ClawHub**: douban-sync-skill@0.1.4
- **GitHub**: [cosformula/douban-sync-skill](https://github.com/cosformula/douban-sync-skill)