### PR TITLE
Add skill: chadru/appraisal-ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -3045,6 +3045,7 @@ If you think a skill was incorrectly excluded or miscategorized, feel free to op
 - [agent-intelligence-network-scan](https://github.com/openclaw/skills/tree/main/skills/lvcidpsyche/agent-intelligence-network-scan/SKILL.md) - Query agent reputation
 - [agentsbank](https://github.com/openclaw/skills/tree/main/skills/cryruz/agentsbank/SKILL.md) - is a specialized financial platform designed for AI agents.
 - [ai-pdf-builder](https://github.com/openclaw/skills/tree/main/skills/nextfrontierbuilds/ai-pdf-builder/SKILL.md) - AI-powered PDF generator for legal docs, pitch
+- [appraisal-ai](https://github.com/openclaw/skills/tree/main/skills/chadru/appraisal-ai/SKILL.md) - Draft real estate appraisal reports with tracked changes.
 - [beautiful-mermaid](https://github.com/openclaw/skills/tree/main/skills/ntlx/beautiful-mermaid/SKILL.md) - Render beautiful Mermaid diagrams as SVGs or ASCII art.
 - [boggle](https://github.com/openclaw/skills/tree/main/skills/christianhaberl/boggle/SKILL.md) - Solve Boggle boards — find all valid words (German + English) on a 4x4
 - [bookkeeping-basics](https://github.com/openclaw/skills/tree/main/skills/jk-0001/bookkeeping-basics/SKILL.md) - Set up and maintain basic bookkeeping for a solopreneur


### PR DESCRIPTION
## Summary

- Adds [appraisal-ai](https://github.com/openclaw/skills/tree/main/skills/chadru/appraisal-ai/SKILL.md) to the **PDF & Documents** category
- Published on ClawHub: `appraisal-ai` v1.1.1
- Drafts real estate appraisal reports (Word narratives with tracked changes, Excel adjustment grids) from project workfiles and master templates
- OpenClaw security scan: **Benign** (high confidence)

## Category

PDF & Documents — the skill produces .docx and .xlsx output from source documents.