### PR TITLE
Add ClawToTalk mobile app

### DIFF
--- a/README.md
+++ b/README.md
@@ -2804,6 +2804,7 @@ If you think a skill was incorrectly excluded or miscategorized, feel free to op
 - [audio-reply](https://github.com/openclaw/skills/tree/main/skills/matrixy/audio-reply-skill/SKILL.md) - Generate audio replies using TTS.
 - [chichi-speech](https://github.com/openclaw/skills/tree/main/skills/hudeven/chichi-speech/SKILL.md) - A RESTful service for high-quality text-to-speech using Qwen3
 - [claw-voice](https://github.com/openclaw/skills/tree/main/skills/niczy/claw-voice/SKILL.md) - You are connected to a live user session via voice.
+- [clawtotalk](https://clawtotalk.com/) - Mobile push-to-talk app for OpenClaw with ElevenLabs voice output (iOS & Android)
 - [clonev](https://github.com/openclaw/skills/tree/main/skills/instant-picture/clonev/SKILL.md) - Clone any voice and generate speech using Coqui XTTS v2.
 - [critical-article-writer](https://github.com/openclaw/skills/tree/main/skills/tomstools11/critical-article-writer/SKILL.md) - Generate draft articles, outlines
 - [cult-of-carcinization](https://github.com/openclaw/skills/tree/main/skills/loserbcc/cult-of-carcinization/SKILL.md) - Give your agent a voice — and ears.


### PR DESCRIPTION
This PR adds ClawToTalk (https://clawtotalk.com/) to the Speech & Transcription section.

ClawToTalk is a mobile companion app for OpenClaw that provides:
- Native push-to-talk interface
- ElevenLabs integration for voice output
- Available on iOS and Android platforms
- Direct connection to OpenClaw instance

This is a useful voice interaction tool for OpenClaw users who prefer mobile, push-to-talk interactions. The app complements the existing ecosystem of voice-related skills and tools in the Speech & Transcription category.