### PR TITLE
Add skill: echennells/sparkbtcbot

### DIFF
--- a/README.md
+++ b/README.md
@@ -3304,6 +3304,7 @@ If you think a skill was incorrectly excluded or miscategorized, feel free to op
 - [og-openclawguard](https://github.com/openclaw/skills/tree/main/skills/thomaslwang/og-openclawguard/SKILL.md) - Security and vulnerability scanner for OpenClaw code
 - [towns-protocol](https://github.com/openclaw/skills/tree/main/skills/andreyz/towns-protocol/SKILL.md) - Use when building Towns Protocol bots - covers SDK
 - [udau](https://github.com/openclaw/skills/tree/main/skills/nicoacosta/udau/SKILL.md) - description: Union protocol for AI agents.
+- [sparkbtcbot](https://github.com/openclaw/skills/tree/main/skills/echennells/sparkbtcbot/SKILL.md) - L402 payment protocol for agent-to-agent micropayments.
 
 </details>
 


### PR DESCRIPTION
## Summary

Adds sparkbtcbot to the **Agent-to-Agent Protocols** category.

### Why Agent-to-Agent Protocols?

This skill implements the **L402 protocol** - an HTTP-native standard for machine-to-machine micropayments. It enables:

- **Agent-to-agent payments** - One AI agent paying another for services
- **Pay-per-call APIs** - Agents accessing paid resources autonomously  
- **Machine commerce** - Programmatic value transfer between software systems

This is fundamentally an **agent coordination protocol** (like claw-to-claw, but for value transfer) rather than a speculative finance tool. L402 is becoming a standard primitive for autonomous agent economies.

### Re: "No crypto" policy

I understand there's a filter for crypto/blockchain/DeFi/finance. This skill is:
- ❌ NOT for trading, speculation, or DeFi
- ❌ NOT a portfolio tracker or exchange integration
- ✅ An **agent protocol** for machine-to-machine payments (like HTTP 402)
- ✅ Comparable to Stripe for traditional payments, but for agent-to-agent use

If this doesn't fit, I completely understand - happy to discuss where it might belong.

---

- [x] Published in openclaw/skills: `skills/echennells/sparkbtcbot`
- [x] Has SKILL.md documentation
- [x] Description under 10 words