### PR TITLE
Add ShadowDB — PostgreSQL persistent memory plugin with vector search

### DIFF
--- a/README.md
+++ b/README.md
@@ -2408,7 +2408,7 @@ If you think a skill was incorrectly excluded or miscategorized, feel free to op
 - [self-reflection](https://github.com/openclaw/skills/tree/main/skills/hopyky/self-reflection/SKILL.md) - Continuous self-improvement through structured reflection
 - [session-wrap-up](https://github.com/openclaw/skills/tree/main/skills/branexp/session-wrap-up/SKILL.md) - Wrap up a conversation session before starting a new one.
 - [shared-memory](https://github.com/openclaw/skills/tree/main/skills/christinetyip/shared-memory/SKILL.md) - Share memories and state with other users.
-- [shadowdb](https://github.com/jamesdwilson/ShadowDB) - PostgreSQL-backed persistent memory with nomic-embed-text vector search, automatic re-embedding on config change, and a digest primer that scales context by model size. Drop-in OpenClaw memory plugin.
+- [shadowdb](https://github.com/jamesdwilson/ShadowDB) - Production-grade persistent memory powered by PostgreSQL + pgvector. Hybrid retrieval (vector similarity, full-text search, recency weighting), automatic re-embedding on config drift, and a model-aware digest primer that feeds small models less context and large models more. 7,000+ records battle-tested. Replaces built-in memory entirely.
 - [shodh-local](https://github.com/openclaw/skills/tree/main/skills/doobidoo/shodh-local/SKILL.md) - Local Shodh-Memory v0.1.74 (offline cognitive memory for AI agents).
 - [skill-from-memory](https://github.com/openclaw/skills/tree/main/skills/zfanmy/skill-from-memory/SKILL.md) - Convert memory, conversation history, or completed tasks
 - [skillcraft](https://github.com/openclaw/skills/tree/main/skills/jmz1/skillcraft/SKILL.md) - Create, design, and package Clawdbot skills.


### PR DESCRIPTION
Adds [ShadowDB](https://github.com/jamesdwilson/ShadowDB) to the **Notes & PKM** category.

## Why ShadowDB exists

The built-in OpenClaw memory is SQLite-backed, single-vector search, and has no awareness of model context limits. ShadowDB replaces it entirely with a production-grade system designed for agents that run 24/7 and accumulate thousands of records.

## What makes it different

| Feature | Built-in Memory | ShadowDB |
|---------|----------------|----------|
| Storage | SQLite file | PostgreSQL + pgvector |
| Search | Vector-only | Hybrid: vector similarity + full-text search + recency weighting (configurable weights) |
| Embedding drift | Manual re-embed | Automatic — fingerprints config on startup, re-embeds in background if anything changed |
| Context injection | Fixed size | Model-aware digest primer — Opus gets 6K chars, Mistral-small gets 2.5K, scales per model |
| Task prefixes | None | nomic-embed-text `search_document:` / `search_query:` prefix support for better retrieval |
| Scale tested | Hundreds | 7,000+ records in daily production use |

## Key capabilities

- **Hybrid retrieval** — Blends vector cosine similarity (0.7), full-text trigram matching (0.3), and recency weighting (0.15). Tunable per deployment.
- **Zero-touch re-embedding** — Change your embedding model, dimensions, or provider and ShadowDB detects the drift via SHA-256 fingerprint, then re-embeds every record in the background. No migration scripts.
- **Model-aware primer** — On session start, injects a digest of recent/important memories scaled to what the current model can handle. Small models get concise summaries; large models get full context.
- **Drop-in plugin** — One path entry in `openclaw.json`, point it at any Postgres instance. Slots into the `memory` plugin slot and all `memory_search` / `memory_write` / `memory_get` tools just work.
- **Retention policies** — Soft-delete with configurable purge-after-days. Records are recoverable until retention cleanup runs.

## Category

Notes & PKM — alphabetically between `shared-memory` and `shodh-local`.