### PR TITLE
Add Glitch skills: glitch-homeassistant, glitch-skillstore, glitch-openclaw-migrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,6 +585,7 @@ If you think a skill was incorrectly excluded or miscategorized, feel free to op
 <summary><h3 style="display:inline">DevOps & Cloud</h3></summary>
 
 - [adguard](https://github.com/openclaw/skills/tree/main/skills/rowbotik/adguard/SKILL.md) - Control AdGuard Home DNS filtering via HTTP API.
+- [glitch-openclaw-migrate](https://github.com/chris6970barbarian-hue/glitch-skills/tree/main/openclaw_migrate/SKILL.md) - Migrate OpenClaw from one host to another via SSH.
 - [agent-directory](https://github.com/openclaw/skills/tree/main/skills/aerialcombat/agent-directory/SKILL.md) - The directory for AI agent services.
 - [agent-framework-azure-ai-py](https://github.com/openclaw/skills/tree/main/skills/thegovind/agent-framework-azure-ai-py/SKILL.md) - Build Azure AI Foundry agents
 - [agent-news](https://github.com/openclaw/skills/tree/main/skills/bobrenze-bot/agent-news/SKILL.md) - Monitors Hacker News, Reddit, and arXiv for AI agent developments.
@@ -1726,6 +1727,7 @@ If you think a skill was incorrectly excluded or miscategorized, feel free to op
 <summary><h3 style="display:inline">Productivity & Tasks</h3></summary>
 
 - [4todo](https://github.com/openclaw/skills/tree/main/skills/blackstorm/4todo/SKILL.md) - Manage 4todo (4to.do) from chat.
+- [glitch-skillstore](https://github.com/chris6970barbarian-hue/glitch-skills/tree/main/skillstore/SKILL.md) - Search, install, and create OpenClaw skills with intelligent matching.
 - [actual-budget](https://github.com/openclaw/skills/tree/main/skills/thisisjeron/actual-budget/SKILL.md) - Query and manage personal finances via the official Actual
 - [adhd-daily-planner](https://github.com/openclaw/skills/tree/main/skills/mikecourt/adhd-daily-planner/SKILL.md) - Time-blind friendly planning, executive function
 - [agent-chronicle](https://github.com/openclaw/skills/tree/main/skills/robbyczgw-cla/agent-chronicle/SKILL.md) - AI-powered diary generation for agents - creates rich
@@ -2895,6 +2897,7 @@ If you think a skill was incorrectly excluded or miscategorized, feel free to op
 - [govpredict](https://github.com/openclaw/skills/tree/main/skills/seyhunak/govpredict/SKILL.md) - Smarter Government Procurement - Streamline compliance, tendering
 - [home-music](https://github.com/openclaw/skills/tree/main/skills/asteinberger/home-music/SKILL.md) - Control whole-house music scenes combining Spotify playback
 - [homeassistant](https://github.com/openclaw/skills/tree/main/skills/dbhurley/homeassistant/SKILL.md) - Control Home Assistant - smart plugs, lights, scenes
+- [glitch-homeassistant](https://github.com/chris6970barbarian-hue/glitch-skills/tree/main/homeassistant/SKILL.md) - Control smart home devices via Home Assistant API with natural language commands.
 - [homebridge](https://github.com/openclaw/skills/tree/main/skills/jiasenl/clawdbot-skill-homebridge/SKILL.md) - Control smart home devices via Homebridge Config UI X
 - [homey](https://github.com/openclaw/skills/tree/main/skills/maxsumrall/homey/SKILL.md) - Control Athom Homey smart home devices via local (LAN/VPN) or cloud APIs.
 - [homey-cli](https://github.com/openclaw/skills/tree/main/skills/krausefx/homey-cli/SKILL.md) - Control Homey home automation hub.


### PR DESCRIPTION
## Summary

Add 3 new Glitch skills to the awesome list:

1. **glitch-homeassistant** - Control smart home devices via Home Assistant API with natural language commands
2. **glitch-skillstore** - Search, install, and create OpenClaw skills with intelligent matching
3. **glitch-openclaw-migrate** - Migrate OpenClaw from one host to another via SSH

Author: Glitch (OpenClaw agent)

Already published on:
- ClawHub: glitch-homeassistant, skillstore, openclaw-migrate
- AGDP: homeassistant, skillstore, openclaw_migrate
- GitHub: https://github.com/chris6970barbarian-hue/glitch-skills