### PR TITLE
Add skill: billychl1/footballbin-predictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ If you think a skill was incorrectly excluded or miscategorized, feel free to op
 | [Coding Agents & IDEs](#coding-agents--ides) (133) | [Marketing & Sales](#marketing--sales) (143) | [Communication](#communication) (132) |
 | [Git & GitHub](#git--github) (66) | [Productivity & Tasks](#productivity--tasks) (135) | [Speech & Transcription](#speech--transcription) (65) |
 | [Moltbook](#moltbook) (51) | [AI & LLMs](#ai--llms) (287) | [Smart Home & IoT](#smart-home--iot) (56) |
-| [Web & Frontend Development](#web--frontend-development) (202) | [Data & Analytics](#data--analytics) (46) | [Shopping & E-commerce](#shopping--e-commerce) (51) |
+| [Web & Frontend Development](#web--frontend-development) (202) | [Data & Analytics](#data--analytics) (47) | [Shopping & E-commerce](#shopping--e-commerce) (51) |
 | [DevOps & Cloud](#devops--cloud) (212) | [Finance](#finance) (22) | [Calendar & Scheduling](#calendar--scheduling) (50) |
 | [Browser & Automation](#browser--automation) (139) | [Media & Streaming](#media--streaming) (80) | [PDF & Documents](#pdf--documents) (67) |
 | [Image & Video Generation](#image--video-generation) (60) | [Notes & PKM](#notes--pkm) (100) | [Self-Hosted & Automation](#self-hosted--automation) (25) |
@@ -2183,6 +2183,7 @@ If you think a skill was incorrectly excluded or miscategorized, feel free to op
 - [facebook-page-manager](https://github.com/openclaw/skills/tree/main/skills/longmaba/facebook-page-manager/SKILL.md) - Manage Facebook Pages via Meta Graph API.
 - [feishu-pcec](https://github.com/openclaw/skills/tree/main/skills/autogame-17/feishu-pcec/SKILL.md) - Internal wrapper for `capability-evolver` that forces reporting
 - [flexible-data-importer](https://github.com/openclaw/skills/tree/main/skills/sschepis/flexible-data-importer/SKILL.md) - <!-- SKILL-META
+- [footballbin-predictions](https://github.com/openclaw/skills/tree/main/skills/billychl1/footballbin-predictions/SKILL.md) - AI match predictions for Premier League and Champions League.
 - [get-weather](https://github.com/openclaw/skills/tree/main/skills/noypearl/get-weather/SKILL.md) - Fetch current weather and forecast data from a free weather API
 - [google-analytics-api](https://github.com/openclaw/skills/tree/main/skills/rich-song/google-analytics-api/SKILL.md) - Google Analytics API integration with managed
 - [harvest-time-reporting-api](https://github.com/openclaw/skills/tree/main/skills/zachgodsell93/harvest-time-reporting-api/SKILL.md) - Integration with Harvest time


### PR DESCRIPTION
## Summary
- Adds [footballbin-predictions](https://clawhub.ai/skills/footballbin-predictions) to the Data & Analytics category
- AI-powered match predictions for Premier League and Champions League including half-time/full-time scores, next goal scorer, corner counts, and key player analysis

## Changes
- Added entry in alphabetical order in Data & Analytics section
- Updated section count from 46 → 47

## Security
A JSON injection vulnerability in the original script (direct bash string interpolation of user input into JSON) has been fixed — all user inputs are now safely constructed via `jq --arg` flags. Fix PR: https://github.com/openclaw/skills/pull/74

## Test plan
- [x] Verify the skill link resolves correctly
- [x] Verify alphabetical ordering in the Data & Analytics section
- [x] Verify section count updated correctly