### PR TITLE
Add skill: humanjudge-arthur/openclaw-validate

### DIFF
--- a/README.md
+++ b/README.md
@@ -2153,6 +2153,7 @@ If you think a skill was incorrectly excluded or miscategorized, feel free to op
 - [win-mouse-native](https://github.com/openclaw/skills/tree/main/skills/lurklight/win-mouse-native/SKILL.md) - Native Windows mouse control (move, click, drag)
 - [xai](https://github.com/openclaw/skills/tree/main/skills/mvanhorn/xai/SKILL.md) - Chat with Grok models via xAI API.
 - [xuezh](https://github.com/openclaw/skills/tree/main/skills/local/xuezh/SKILL.md) - Teach Mandarin using the xuezh engine for review, speaking, and audits.
+- [openclaw-validate](https://github.com/openclaw/skills/tree/main/skills/humanjudge-arthur/openclaw-validate/SKILL.md) - Real-time human evaluation benchmark for AI agent responses
 
 </details>
 


### PR DESCRIPTION
Adds [openclaw-validate](https://github.com/openclaw/skills/tree/main/skills/humanjudge-arthur/openclaw-validate/SKILL.md) to the **AI & LLMs** category.

### Checklist

- [x] Skill has SKILL.md documentation
- [x] Published in official OpenClaw skills repo
- [x] Description under 10 words
- [x] Link verified as working
- [x] No duplicate skill with identical purpose
- [x] Added at end of AI & LLMs section