### PR TITLE
Add skill: billychl1/footballbin-predictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <br/>
 
 <div align="center">
-    <strong>Discover 3002 community-built OpenClaw skills, organized by category.
+    <strong>Discover 3003 community-built OpenClaw skills, organized by category.
     </strong>
     <br />
     <br />
@@ -20,7 +20,7 @@
 </a> 
 
 [![AI Agent Papers](https://img.shields.io/badge/AI%20Agent-Research%20Papers-b31b1b)](https://github.com/VoltAgent/awesome-ai-agent-papers)
-![Skills Count](https://img.shields.io/badge/skills-3002-blue?style=flat-square)
+![Skills Count](https://img.shields.io/badge/skills-3003-blue?style=flat-square)
 ![Last Update](https://img.shields.io/github/last-commit/VoltAgent/awesome-clawdbot-skills?label=Last%20update&style=flat-square)
 [![Discord](https://img.shields.io/discord/1361559153780195478.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://s.voltagent.dev/discord)
 [![GitHub forks](https://img.shields.io/github/forks/VoltAgent/awesome-clawdbot-skills?style=social)](https://github.com/VoltAgent/awesome-claude-skills/network/members)
@@ -94,7 +94,7 @@ If you think a skill was incorrectly excluded or miscategorized, feel free to op
 | [Coding Agents & IDEs](#coding-agents--ides) (133) | [Marketing & Sales](#marketing--sales) (143) | [Communication](#communication) (132) |
 | [Git & GitHub](#git--github) (66) | [Productivity & Tasks](#productivity--tasks) (135) | [Speech & Transcription](#speech--transcription) (65) |
 | [Moltbook](#moltbook) (51) | [AI & LLMs](#ai--llms) (287) | [Smart Home & IoT](#smart-home--iot) (56) |
-| [Web & Frontend Development](#web--frontend-development) (202) | [Data & Analytics](#data--analytics) (46) | [Shopping & E-commerce](#shopping--e-commerce) (51) |
+| [Web & Frontend Development](#web--frontend-development) (202) | [Data & Analytics](#data--analytics) (47) | [Shopping & E-commerce](#shopping--e-commerce) (51) |
 | [DevOps & Cloud](#devops--cloud) (212) | [Finance](#finance) (22) | [Calendar & Scheduling](#calendar--scheduling) (50) |
 | [Browser & Automation](#browser--automation) (139) | [Media & Streaming](#media--streaming) (80) | [PDF & Documents](#pdf--documents) (67) |
 | [Image & Video Generation](#image--video-generation) (60) | [Notes & PKM](#notes--pkm) (100) | [Self-Hosted & Automation](#self-hosted--automation) (25) |
@@ -2353,6 +2353,7 @@ If you think a skill was incorrectly excluded or miscategorized, feel free to op
 - [feishu-memory-recall](https://github.com/openclaw/skills/tree/main/skills/autogame-17/feishu-memory-recall/SKILL.md) - This skill allows the agent to recover "lost"
 - [fizzy-cli](https://github.com/openclaw/skills/tree/main/skills/tobiasbischoff/fizzy-cli/SKILL.md) - Use the fizzy-cli tool to authenticate and manage Fizzy kanban
 - [flomo-notes](https://github.com/openclaw/skills/tree/main/skills/xiaoluoboding/flomo-notes/SKILL.md) - Save notes to Flomo via the Flomo inbox webhook.
+- [footballbin-predictions](https://github.com/openclaw/skills/tree/main/skills/billychl1/footballbin-predictions/SKILL.md) - Get AI-powered match predictions for Premier League and Champions League including scores, next goal scorer, corners, and key player analysis.
 - [fsxmemory](https://github.com/openclaw/skills/tree/main/skills/azrijamil/fsxmemory/SKILL.md) - Structured memory system for AI agents.
 - [gdocs-markdown](https://github.com/openclaw/skills/tree/main/skills/techlaai/gdocs-markdown/SKILL.md) - Create Google Docs from Markdown files.
 - [gkeep](https://github.com/openclaw/skills/tree/main/skills/vacinc/gkeep/SKILL.md) - Google Keep notes via gkeepapi.


### PR DESCRIPTION
## Summary
- Adds [footballbin-predictions](https://clawhub.ai/skills/footballbin-predictions) to the Data & Analytics category
- AI-powered match predictions for Premier League and Champions League including half-time/full-time scores, next goal scorer, corner counts, and key player analysis

## Changes
- Added entry in alphabetical order in Data & Analytics section
- Updated section count from 46 → 47
- Updated total skills count from 3002 → 3003

## Test plan
- [x] Verify the skill link resolves correctly on clawhub.ai
- [x] Verify alphabetical ordering in the Data & Analytics section
- [x] Verify section count updated correctly