### PR TITLE
Add openclaw-node-setup: remote node setup with emergency recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -726,6 +726,7 @@ If you think a skill was incorrectly excluded or miscategorized, feel free to op
 - [npm-proxy](https://github.com/openclaw/skills/tree/main/skills/weird-aftertaste/npm-proxy/SKILL.md) - Manage Nginx Proxy Manager (NPM) hosts, certificates, and access
 - [openclaw-confluence-skill](https://github.com/openclaw/skills/tree/main/skills/pangin/openclaw-confluence-skill/SKILL.md) - Full Confluence Cloud REST API v2 skill
 - [openclaw-nextcloud](https://github.com/openclaw/skills/tree/main/skills/keithvassallomt/openclaw-nextcloud/SKILL.md) - Manage Notes, Tasks, Calendar, Files
+- [openclaw-node-setup](https://github.com/yujesyoga/openclaw-node-setup) - Set up remote OpenClaw nodes for execution, browser proxy, and emergency Gateway recovery. Battle-tested with 7 common pitfalls documented.
 - [openclaw-setup](https://github.com/openclaw/skills/tree/main/skills/j540/openclaw-setup/SKILL.md) - Set up a complete OpenClaw personal AI assistant from scratch
 - [openclaws](https://github.com/openclaw/skills/tree/main/skills/amoghacloud/openclaws/SKILL.md) - Join the first decentralized social network for AI agents.
 - [pi-admin](https://github.com/openclaw/skills/tree/main/skills/thesethrose/pi-admin/SKILL.md) - Raspberry Pi system administration.


### PR DESCRIPTION
## New Skill: openclaw-node-setup

**Repo:** https://github.com/yujesyoga/openclaw-node-setup

### What it does
Set up and manage OpenClaw remote nodes — headless hosts for remote execution, browser proxy (residential IP), and emergency Gateway recovery via SSH.

### Why it's useful
Setting up a remote node has several non-obvious pitfalls (nginx + WebSocket, HTTP/2 ALPN, device vs node pairing commands, Gateway bind config, Tailscale SSH approval, macOS sleep prevention). This skill documents 7 battle-tested gotchas that each cost 15-60 minutes to debug.

### Covers
- macOS & Linux installation and service setup
- Browser proxy (Playwright Chromium)
- Emergency recovery scripts (SSH back to Gateway)
- macOS anti-sleep configuration (pmset)
- Security checklist

**Category:** DevOps & Cloud