### PR TITLE
Add skill: wgj/redline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1400,6 +1400,7 @@ If you think a skill was incorrectly excluded or miscategorized, feel free to op
 - [pokemon-red](https://github.com/openclaw/skills/tree/main/skills/drbarq/pokemon-red/SKILL.md) - Play Pokemon Red autonomously via PyBoy emulator.
 - [project-management-skills](https://github.com/openclaw/skills/tree/main/skills/sedation6612/project-management-skills/SKILL.md) - A governed project management OS
 - [prompt-guard](https://github.com/openclaw/skills/tree/main/skills/seojoonkim/prompt-guard/SKILL.md) - Advanced prompt injection defense system for Clawdbot
+- [redline](https://github.com/openclaw/skills/tree/main/skills/wgj/redline/SKILL.md) - Live rate-limit awareness for Claude.ai and OpenAI with automatic pacing tiers.
 - [scrappa-skill](https://github.com/openclaw/skills/tree/main/skills/userlip/scrappa-skill/SKILL.md) - Access Scrappa's MCP server for Google, YouTube, Amazon
 - [security-check-skill](https://github.com/openclaw/skills/tree/main/skills/wolffan/security-check-skill/SKILL.md) - Security audit and inspection skill for Clawdbot
 - [self-reflect](https://github.com/openclaw/skills/tree/main/skills/stevengonsalvez/self-reflect/SKILL.md) - Self-improvement through conversation analysis.


### PR DESCRIPTION
**RedLine** — Live rate-limit awareness for Claude.ai (Max/Pro) and OpenAI (Plus/Pro/Codex).

Two CLI scripts + a 4-tier pacing strategy (GREEN/YELLOW/ORANGE/RED) that keeps autonomous agents running at maximum token efficiency without hitting limits.

- Published on ClawHub: [wgj/redline](https://clawhub.ai/wgj/redline) (v0.2.0)
- Skills repo PR: openclaw/skills#82
- Source: [github.com/wgj/redline](https://github.com/wgj/redline)

Category: Clawdbot Tools (alphabetical placement between prompt-guard and scrappa-skill)