### PR TITLE
Add AgentCanary - market intelligence API for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [agent-identity-kit](https://github.com/openclaw/skills/tree/main/skills/ryancampbell/agent-identity-kit/SKILL.md) - A portable identity system for AI agents.
 - [agenticflow-skill](https://github.com/openclaw/skills/tree/main/skills/seanphan/agenticflow-skill/SKILL.md) - Comprehensive guide for building AI workflows, agents
 - [agentlens](https://github.com/openclaw/skills/tree/main/skills/nguyenphutrong/agentlens/SKILL.md) - Navigate and understand codebases using agentlens hierarchical
+- [agentcanary](https://agentcanary.ai) - Market intelligence API for AI agents. 33 endpoints covering macro regime detection, trading signals, whale alerts, funding arbitrage, orderbook analytics, breaking news with FinBERT sentiment, and more. 1,181 assets from 250+ sources.
 - [agentskills-io](https://github.com/openclaw/skills/tree/main/skills/killerapp/agentskills-io/SKILL.md) - Create, validate, and publish Agent Skills following
 - [aisa-twitter-api](https://github.com/openclaw/skills/tree/main/skills/aisapay/aisa-twitter-api/SKILL.md) - Search X (Twitter) in real time, extract relevant posts
 - [apple-hig](https://github.com/openclaw/skills/tree/main/skills/kdbhalala/apple-hig/SKILL.md) - Expert guide for designing iOS, macOS, watchOS, tvOS, and visionOS apps.


### PR DESCRIPTION
Adding AgentCanary to the skills list.

**What it does:** Market intelligence API for AI agents — macro regime detection, trading signals, whale alerts, funding arbitrage, orderbook analytics, breaking news with FinBERT sentiment, economic calendar, treasury tracking.

- 33 endpoints, 1,181 assets, 250+ data sources
- API-only, read-only, no local code execution
- Live proof: [@AgentCanary on Telegram](https://t.me/AgentCanary) posts 3x/day
- Website: [agentcanary.ai](https://agentcanary.ai)