### PR TITLE
Add skill: rsavitt/swarm-safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -1288,6 +1288,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [srt](https://github.com/openclaw/skills/tree/main/skills/khj809/srt/SKILL.md) - Korean SRT (Super Rapid Train) search, reservation, and booking management.
 - [startups](https://github.com/openclaw/skills/tree/main/skills/networkingit/startups/SKILL.md) - Research startups, funding rounds, acquisitions, and hiring trends
 - [super-websearch-realtime](https://github.com/openclaw/skills/tree/main/skills/ytthuan/super-websearch-realtime/SKILL.md) - Priority live web search for real-time
+- [swarm-safety](https://github.com/openclaw/skills/tree/main/skills/rsavitt/swarm-safety/SKILL.md) - Multi-agent AI safety simulation with soft probabilistic labels
 - [tavily](https://github.com/openclaw/skills/tree/main/skills/arun-8687/tavily-search/SKILL.md) - AI-optimized web search via Tavily API.
 - [testresearchskill](https://github.com/openclaw/skills/tree/main/skills/cyberengage/testresearchskill/SKILL.md) - Magic 8-Ball fortune teller: selects and returns one
 - [tg](https://github.com/openclaw/skills/tree/main/skills/arein/tg/SKILL.md) - Telegram CLI for reading, searching.


### PR DESCRIPTION
## Summary

- Adds [swarm-safety](https://github.com/openclaw/skills/tree/main/skills/rsavitt/swarm-safety/SKILL.md) to the **Search & Research** category
- Multi-agent AI safety simulation with soft probabilistic labels
- Published on ClawHub: `swarm-safety` v1.7.0 by `rsavitt`
- ClawHub syncs to `openclaw/skills` automatically

## Checklist

- [x] Skill is published on ClawHub (slug: `swarm-safety`, version: 1.7.0)
- [x] Has SKILL.md with documentation
- [x] Description is 10 words or fewer
- [x] Added in alphabetical order within category
- [x] Not crypto/blockchain/DeFi/finance