### PR TITLE
Add mycrab-tunnel-skill: Cloudflare Tunnel automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,6 +590,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [appdeploy](https://github.com/openclaw/skills/tree/main/skills/avimak/appdeploy/SKILL.md) - Deploy web apps with backend APIs, database.
 - [arcane-docker-manager](https://github.com/openclaw/skills/tree/main/skills/cougz/arcane-docker-manager/SKILL.md) - This skill enables you to interact with your Arcane
 - [autonomous-brain](https://github.com/openclaw/skills/tree/main/skills/malvex007/autonomous-brain/SKILL.md) - Advanced autonomous AI brain with proactive monitoring
+- [mycrab-tunnel-skill](https://github.com/isgudtek/mycrab-tunnel-skill) - Autonomous Cloudflare Tunnel setup via mycrab.space API. One-click tunnel install, tunnel management, custom domains, 12+ templates.
 - [autoresponder](https://github.com/openclaw/skills/tree/main/skills/koba42corp/autoresponder/SKILL.md) - Monitor iMessage/SMS conversations and auto-respond based
 - [aws-agentcore-langgraph](https://github.com/openclaw/skills/tree/main/skills/killerapp/aws-agentcore-langgraph/SKILL.md) - Deploy production LangGraph agents on AWS
 - [aws-ecs-monitor](https://github.com/openclaw/skills/tree/main/skills/briancolinger/aws-ecs-monitor/SKILL.md) - AWS ECS production health monitoring with CloudWatch


### PR DESCRIPTION
## Summary
- Added **mycrab-tunnel-skill** to DevOps & Cloud category

## Features
- Autonomous Cloudflare Tunnel setup via mycrab.space API
- One-click tunnel installation for AI agents
- Tunnel management (start, stop, restart)
- Free auto-generated subdomains or custom paid domains
- 12+ 1-click templates

## Links
- Repo: https://github.com/isgudtek/mycrab-tunnel-skill