### PR TITLE
Add camofox-mcp: Anti-detection browser automation MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -814,6 +814,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [camoufox](https://github.com/openclaw/skills/tree/main/skills/goodgoodjm/camoufox/SKILL.md) - Anti-detect browser automation using Camoufox (Firefox-based).
 - [camoufox-stealth](https://github.com/openclaw/skills/tree/main/skills/kesslerio/camoufox-stealth/SKILL.md) - C++ level anti-bot browser automation using Camoufox
 - [camoufox-stealth-browser](https://github.com/openclaw/skills/tree/main/skills/kesslerio/camoufox-stealth-browser/SKILL.md) - C++ level anti-bot browser automation
+- [camofox-mcp](https://github.com/openclaw/skills/tree/main/skills/redf0x1/camofox-mcp/SKILL.md) - Anti-detection browser automation MCP with C++ fingerprint spoofing.
 - [chatgpt-exporter-ultimate](https://github.com/openclaw/skills/tree/main/skills/globalcaos/chatgpt-exporter-ultimate/SKILL.md) - Export ALL your ChatGPT conversations
 - [chirp](https://github.com/openclaw/skills/tree/main/skills/zizi-cat/chirp/SKILL.md) - X/Twitter CLI using OpenClaw browser tool.
 - [claude-chrome](https://github.com/openclaw/skills/tree/main/skills/dgriffin831/claude-chrome/SKILL.md) - Use Claude Code with Chrome browser extension for web


### PR DESCRIPTION
Adds [camofox-mcp](https://github.com/redf0x1/camofox-mcp) — published to ClawHub at [clawhub.ai/redf0x1/camofox-mcp](https://clawhub.ai/redf0x1/camofox-mcp).

**What it does:**
- 41 browser automation tools via MCP protocol
- C++ level fingerprint spoofing — passes bot detection
- Search 14 engines without CAPTCHAs
- HTTP transport for easy OpenClaw integration

**Setup:**
```
CAMOFOX_TRANSPORT=http npx camofox-mcp
```

npm: https://www.npmjs.com/package/camofox-mcp
GitHub: https://github.com/redf0x1/camofox-mcp
ClawHub: https://clawhub.ai/redf0x1/camofox-mcp