### PR TITLE
Add skill: r-m-naveen/atxp-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -1426,6 +1426,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [agent-commerce-engine](https://github.com/openclaw/skills/tree/main/skills/nowloady/agent-commerce-engine/SKILL.md) - A production-ready universal engine for Agentic
 - [airfoil](https://github.com/openclaw/skills/tree/main/skills/asteinberger/airfoil/SKILL.md) - Control AirPlay speakers via Airfoil from the command line.
 - [aria2-json-rpc](https://github.com/openclaw/skills/tree/main/skills/azzgo/aria2-json-rpc/SKILL.md) - Interact with aria2 download manager via JSON-RPC 2.0.
+- [atxp-cli](https://github.com/openclaw/skills/tree/main/skills/r-m-naveen/atxp-2/SKILL.md) - Agent infrastructure CLI with wallet, email, phone, and search.
 - [brew-install](https://github.com/openclaw/skills/tree/main/skills/xejrax/brew-install/SKILL.md) - Install missing binaries via dnf (Fedora/Bazzite package manager).
 - [bun-runtime](https://github.com/openclaw/skills/tree/main/skills/rabin-thami/bun-runtime/SKILL.md) - Bun runtime capabilities for filesystem, process.
 - [camsnap](https://github.com/openclaw/skills/tree/main/skills/steipete/camsnap/SKILL.md) - Capture frames or clips from RTSP/ONVIF cameras.


### PR DESCRIPTION
## Summary

- **Skill**: [atxp-cli](https://github.com/openclaw/skills/tree/main/skills/r-m-naveen/atxp-2/SKILL.md)
- **Author**: r-m-naveen
- **ClawHub**: https://clawhub.ai/R-M-Naveen/atxp-cli
- **npm**: [atxp](https://www.npmjs.com/package/atxp)
- **Source**: [github.com/atxp-dev/cli](https://github.com/atxp-dev/cli)
- **Category**: CLI Utilities

Agent infrastructure CLI that gives AI agents a funded identity — wallet, email, phone, and access to paid API tools (web search, AI image/video/music generation, X/Twitter search, SMS, voice calls, 100+ LLM models). One `npx` command to register, fund, and start using.

## Checklist

- [x] Skill is published in the [OpenClaw skills repo](https://github.com/openclaw/skills/tree/main/skills/r-m-naveen/atxp-2)
- [x] Has SKILL.md documentation
- [x] Description is concise (10 words)
- [x] Added to the end of the matching category (CLI Utilities, alphabetical)
- [x] Not a duplicate of an existing entry (existing `atxp` entry by `emilioacc` is a separate publish by a co-team member)
- [x] Link verified and working