### PR TITLE
Add skill: jlm-coffee (Jerusalem specialty coffee finder)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2975,6 +2975,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [idealista](https://github.com/openclaw/skills/tree/main/skills/quifago/idealista/SKILL.md) - Query Idealista API via idealista-cli (OAuth2 client credentials).
 - [irish-takeaway](https://github.com/openclaw/skills/tree/main/skills/cotyledonlab/irish-takeaway/SKILL.md) - Find nearby takeaways in Ireland and browse menus.
 - [jellyseerr](https://github.com/openclaw/skills/tree/main/skills/ericrosenberg/jellyseerr/SKILL.md) - Request movies and TV shows through Jellyseerr.
+- [jlm-coffee](https://github.com/openclaw/skills/tree/main/skills/alexpolonsky/jlm-coffee/SKILL.md) - Search specialty coffee shops in Jerusalem by amenities and hours.
 - [jtbd-analyzer](https://github.com/openclaw/skills/tree/main/skills/artyomx33/jtbd-analyzer/SKILL.md) - Uncover the real "job" customers hire your product
 - [marketplace-clis](https://github.com/openclaw/skills/tree/main/skills/pjtf93) - Spanish marketplace CLIs: Wallapop, Idealista,...
 - [marktplaats](https://github.com/openclaw/skills/tree/main/skills/pvoo/marktplaats/SKILL.md) - Search Marktplaats.nl classifieds across all categories with filtering


### PR DESCRIPTION
## Summary

Adds [jlm-coffee](https://clawhub.ai/skills/jlm-coffee) by [alexpolonsky](https://github.com/alexpolonsky) to Shopping & E-commerce.

Search specialty coffee shops in Jerusalem by name, amenities, ratings, and opening hours. Community-curated data from [coffee.amsterdamski.com](https://coffee.amsterdamski.com).

Published on ClawHub, pending mirror sync to openclaw/skills.