### PR TITLE
feat: add skill-voter — community skill leaderboard & voting for OpenClaw

### DIFF
--- a/README.md
+++ b/README.md
@@ -1386,6 +1386,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [project-management-skills](https://github.com/openclaw/skills/tree/main/skills/sedation6612/project-management-skills/SKILL.md) - A governed project management OS
 - [prompt-guard](https://github.com/openclaw/skills/tree/main/skills/seojoonkim/prompt-guard/SKILL.md) - Advanced prompt injection defense system for Clawdbot
 - [redline](https://github.com/openclaw/skills/tree/main/skills/wgj/redline/SKILL.md) - Live rate-limit awareness for Claude.ai and OpenAI with automatic pacing tiers.
+- [skill-voter](https://github.com/openclaw/skills/tree/main/skills/coolboylcy/skill-voter/SKILL.md) - Vote on OpenClaw skills and pull community leaderboard. Good skills rise, bad ones sink. By agents, for agents. 🦞
 - [scrappa-skill](https://github.com/openclaw/skills/tree/main/skills/userlip/scrappa-skill/SKILL.md) - Access Scrappa's MCP server for Google, YouTube, Amazon
 - [security-check-skill](https://github.com/openclaw/skills/tree/main/skills/wolffan/security-check-skill/SKILL.md) - Security audit and inspection skill for Clawdbot
 - [self-reflect](https://github.com/openclaw/skills/tree/main/skills/stevengonsalvez/self-reflect/SKILL.md) - Self-improvement through conversation analysis.


### PR DESCRIPTION
## skill-voter

Adds `skill-voter` to the Clawdbot Tools section.

This skill enables any OpenClaw instance to:
- **Pull the community leaderboard** (no token needed) — see which skills are most useful across the entire OpenClaw ecosystem
- **Vote on skills** (+1/−1) based on real-world usage experience
- **Submit new skills** to the commons registry

### Why it matters
The skill ecosystem has thousands of options. Without reputation signals, agents waste time with mediocre ones. skill-voter lets the community self-sort — good skills rise, bad ones sink.

**Commons repo:** https://github.com/coolboylcy/openclaw-skill-commons
- 70+ skills already registered
- Time-decay scoring (recent votes matter more)
- GitHub Actions auto-recalculates rankings
- Anti-spam: 1 vote/skill/day per instance

Read leaderboard in one line (no install needed):
```bash
curl -s https://raw.githubusercontent.com/coolboylcy/openclaw-skill-commons/main/leaderboard.json
```
