### PR TITLE
docs: add restart-guard skill to DevOps & Cloud category

### DIFF
--- a/categories/devops-and-cloud.md
+++ b/categories/devops-and-cloud.md
@@ -300,6 +300,7 @@
 - [qwen3-tts-instruct](https://github.com/openclaw/skills/tree/main/skills/yanmoon321/qwen3-tts-instruct/SKILL.md) - Alibaba Cloud Bailian Qwen TTS with voice/mood presets.
 - [qwen3-tts-local-inference](https://github.com/openclaw/skills/tree/main/skills/jithinm/qwen3-tts-local-inference/SKILL.md) - Generate speech from text using Qwen3-TTS via direct Python inference — no server required.
 - [railway-deploy](https://github.com/openclaw/skills/tree/main/skills/dbanys/railway-deploy/SKILL.md) - This skill should be used when the user wants to push code to Railway, says "railway up", "deploy", "deploy.
+- [restart-guard](https://github.com/Zjianru/restart-guard) - Deterministic gateway restart with state-machine verification and disaster notification fallback.
 - [ralph-quick](https://github.com/openclaw/skills/tree/main/skills/dorukardahan/ralph-quick/SKILL.md) - Fast security spot-check with 10 iterations (~5-10 min)
 - [ralph-security](https://github.com/openclaw/skills/tree/main/skills/dorukardahan/ralph-security/SKILL.md) - Comprehensive security audit with 100 iterations (~30-60 min)
 - [recruitly-mcp](https://github.com/openclaw/skills/tree/main/skills/willgary/recruitly-mcp/SKILL.md) - Search candidates, manage jobs, view pipelines, track billing and team performance in Recruitly CRM via MCP.


### PR DESCRIPTION
## English

Add `restart-guard` skill to the DevOps & Cloud category.

**Description:**  
Deterministic OpenClaw gateway restart with down/up state-machine verification, origin-session proactive ACK, and backward-compatible config.

**Features:**
- Strict state-machine verification: `down_detected && start_attempted && up_healthy`
- Disaster notification fallback (origin session → agent:main:main → external channels)
- Strict non-shell execution (rejects shell metacharacters)
- No extra port binding

**Link:** https://github.com/Zjianru/restart-guard

---

## 中文

在 DevOps & Cloud 类别中添加 `restart-guard` skill。

**描述：**  
确定性的 OpenClaw 网关重启，包含 down/up 状态机验证、源会话主动确认和向后兼容配置。

**特性：**
- 严格状态机验证：`down_detected && start_attempted && up_healthy`
- 灾难通知回退（源会话 → agent:main:main → 外部渠道）
- 严格非 shell 执行（拒绝 shell 元字符）
- 不新增端口监听

**链接：** https://github.com/Zjianru/restart-guard