### PR TITLE
Add polymarket-paper-trader to Data & Analytics

### DIFF
--- a/categories/data-and-analytics.md
+++ b/categories/data-and-analytics.md
@@ -2,7 +2,7 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**42 skills**
+**43 skills**
 
 - [add-analytics](https://github.com/openclaw/skills/tree/main/skills/jeftekhari/add-analytics/SKILL.md) - Add Google Analytics 4 tracking to any project.
 - [agi-artificial-geometric-intelligence](https://github.com/openclaw/skills/tree/main/skills/uniaolives) - Designed multi-layer.
@@ -35,6 +35,7 @@
 - [netlify](https://github.com/openclaw/skills/tree/main/skills/ajmwagar/netlify/SKILL.md) - Use the Netlify CLI (netlify) to create/link Netlify sites and set up CI/CD.
 - [nocodb](https://github.com/openclaw/skills/tree/main/skills/nickian/nocodb/SKILL.md) - Access and manage NocoDB databases, tables, and records via REST API.
 - [osint-graph-analyzer](https://github.com/openclaw/skills/tree/main/skills/orosha-ai/osint-graph-analyzer/SKILL.md) - Build knowledge graphs from OSINT data.
+- [polymarket-paper-trader](https://github.com/agent-next/polymarket-paper-trader) - Paper trading simulator for Polymarket prediction markets. Built for AI agents with MCP server, live order books, strategy backtesting, and shareable stats cards.
 - [remove-analytics](https://github.com/openclaw/skills/tree/main/skills/jeftekhari/remove-analytics/SKILL.md) - Safely remove Google Analytics from a project.
 - [senior-data-engineer](https://github.com/openclaw/skills/tree/main/skills/alirezarezvani/senior-data-engineer/SKILL.md) - Data engineering skill for building scalable.
 - [senior-data-scientist](https://github.com/openclaw/skills/tree/main/skills/alirezarezvani/senior-data-scientist/SKILL.md) - World-class data science skill.


### PR DESCRIPTION
## Summary

Adds [polymarket-paper-trader](https://github.com/agent-next/polymarket-paper-trader) to the Data & Analytics category.

Paper trading simulator for Polymarket prediction markets — built for AI agents. Features:
- MCP server with 25 tools for direct AI agent integration
- Live order book execution with real Polymarket prices
- Strategy backtesting engine
- Shareable stats cards (X/Twitter, Telegram, Discord)
- Leaderboard entries for ranking/PK
- 533 tests, 100% coverage

Install: `npx clawhub install polymarket-paper-trader`

## Category

Data & Analytics — fits alongside other financial/market data skills like `hyperliquid`, `yahoo-data-fetcher`, and `ceorater`.