### PR TITLE
Add human-browser and polyclawster-agent skills by @al1enjesus

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [healthkit-sync](https://github.com/openclaw/skills/tree/main/skills/mneves75/healthkit-sync/SKILL.md) - iOS HealthKit data sync CLI commands and patterns.
 - [hergunmac](https://github.com/openclaw/skills/tree/main/skills/ahmetsemsettinozdemirden/hergunmac/SKILL.md) - Access AI-powered football match predictions.
 - [homebrew](https://github.com/openclaw/skills/tree/main/skills/thesethrose/homebrew/SKILL.md) - Homebrew package manager for macOS.
+- [human-browser](https://github.com/al1enjesus/human-browser) - Stealth Playwright browser with residential proxy for AI agents. Bypasses Cloudflare, DataDome, PerimeterX. iPhone 15 Pro fingerprint. Free trial included. `clawhub install human-browser`
 - [icloud-findmy](https://github.com/openclaw/skills/tree/main/skills/liamnichols/icloud-findmy/SKILL.md) - Query Find My locations and battery status for family devices.
 - [ics-import-on-iphone](https://github.com/openclaw/skills/tree/main/skills/sbhhbs/ics-import-on-iphone/SKILL.md) - Create calendar events by generating valid .ics files when direct calendar access is unavailable.
 - [imessage-signal-analyzer](https://github.com/openclaw/skills/tree/main/skills/terellison/imessage-signal-analyzer/SKILL.md) - Analyze iMessage (macOS) and Signal conversation history to reveal relationship dynamics — message volume.
@@ -656,6 +657,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [openssl](https://github.com/openclaw/skills/tree/main/skills/asleep123/openssl/SKILL.md) - Generate secure random strings, passwords, and cryptographic tokens.
 - [page-cro](https://github.com/openclaw/skills/tree/main/skills/jchopard69/marketing-skills/references/page-cro/SKILL.md) - When the user wants to optimize, improve.
 - [plaid](https://github.com/openclaw/skills/tree/main/skills/jverdi/plaid/SKILL.md) - plaid-cli a cli for interacting with the plaid finance platform.
+- [polyclawster-agent](https://github.com/al1enjesus/polyclawster) - Trade Polymarket prediction markets automatically. Whale wallet tracking, AI signal scoring 0–10, Kelly criterion sizing, non-custodial Polygon wallet. `clawhub install polyclawster-agent`
 - [publisher](https://github.com/openclaw/skills/tree/main/skills/tunaissacoding/publisher/SKILL.md) - Make your skills easy to understand and impossible to ignore.
 - [relationship-skills](https://github.com/openclaw/skills/tree/main/skills/jhillin8/relationship-skills/SKILL.md) - Improve relationships with communication tools.
 - [sharesight-skill](https://github.com/openclaw/skills/tree/main/skills/lextoumbourou/sharesight-skill/SKILL.md) - Manage Sharesight portfolios, holdings, and custom.


### PR DESCRIPTION
## New skills from @al1enjesus / Virix Labs

### 🕵️ human-browser — Browser & Automation
Stealth Playwright browser with residential proxy for AI agents. Bypasses Cloudflare, DataDome, PerimeterX. Real iPhone 15 Pro fingerprint. Free trial included.
- GitHub: https://github.com/al1enjesus/human-browser
- ClawHub: https://clawhub.ai/al1enjesus/human-browser
- Install: `clawhub install human-browser`

### 📈 polyclawster-agent — Finance
Trade Polymarket prediction markets automatically. Whale wallet tracking, AI signal scoring 0–10, Kelly criterion bet sizing, non-custodial Polygon USDC wallet.
- GitHub: https://github.com/al1enjesus/polyclawster
- ClawHub: https://clawhub.ai/al1enjesus/polyclawster-agent
- Install: `clawhub install polyclawster-agent`