### PR TITLE
Add skill: brunobuddy/manifest-build

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 |---|---|---|
 | [Git & GitHub](#git--github) (170) | [Marketing & Sales](#marketing--sales) (104) | [Communication](#communication) (149) |
 | [Coding Agents & IDEs](#coding-agents--ides) (1222) | [Productivity & Tasks](#productivity--tasks) (206) | [Speech & Transcription](#speech--transcription) (45) |
-| [Browser & Automation](#browser--automation) (335) | [AI & LLMs](#ai--llms) (196) | [Smart Home & IoT](#smart-home--iot) (43) |
+| [Browser & Automation](#browser--automation) (335) | [AI & LLMs](#ai--llms) (197) | [Smart Home & IoT](#smart-home--iot) (43) |
 | [Web & Frontend Development](#web--frontend-development) (938) | [Data & Analytics](#data--analytics) (28) | [Shopping & E-commerce](#shopping--e-commerce) (55) |
 | [DevOps & Cloud](#devops--cloud) (408) | [Finance](#finance) (21) | [Calendar & Scheduling](#calendar--scheduling) (61) |
 | [Image & Video Generation](#image--video-generation) (169) | [Media & Streaming](#media--streaming) (85) | [PDF & Documents](#pdf--documents) (111) |
@@ -602,7 +602,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [agentchan](https://github.com/openclaw/skills/tree/main/skills/vvsotnikov) - The anonymous imageboard built for AI agents.**.
 - [agentic-ai-gold-test](https://github.com/openclaw/skills/tree/main/skills/amitabhainarunachala) - Self-improving agent framework.
 
-> **[View all 196 skills in AI & LLMs →](categories/ai-and-llms.md)**
+> **[View all 197 skills in AI & LLMs →](categories/ai-and-llms.md)**
 </details>
 
 <details>

--- a/categories/ai-and-llms.md
+++ b/categories/ai-and-llms.md
@@ -2,7 +2,7 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**196 skills**
+**197 skills**
 
 - [4claw](https://github.com/openclaw/skills/tree/main/skills/mfergpt/4claw/SKILL.md) - 4claw — a moderated imageboard for AI agents.
 - [aap-passport](https://github.com/openclaw/skills/tree/main/skills/ira-hash/aap-passport/SKILL.md) - Agent Attestation Protocol - The Reverse Turing Test.
@@ -121,6 +121,7 @@
 - [llmfit](https://github.com/openclaw/skills/tree/main/skills/alexsjones/llmfit/SKILL.md) - Detect local hardware (RAM, CPU, GPU/VRAM) and recommend the best-fit local LLM models with optimal quantization.
 - [local-llama-tts](https://github.com/openclaw/skills/tree/main/skills/wuxxin/local-llama-tts/SKILL.md) - Local text-to-speech using llama-tts (llama.cpp) and OuteTTS-1.0-0.6B model.
 - [mantis-manager](https://github.com/openclaw/skills/tree/main/skills/willykinfoussia/mantis-manager/SKILL.md) - Manage Mantis Bug Tracker (issues, projects, users, filters, configs) via the official Mantis REST API.
+- [manifest-build](https://github.com/openclaw/skills/tree/main/skills/brunobuddy/manifest-build/SKILL.md) - Open-source LLM routing and cost tracking plugin.
 - [matchmaking](https://github.com/openclaw/skills/tree/main/skills/amirmabhout/matchmaking/SKILL.md) - Agent matchmaking - find meaningful connections for your humans.
 - [meeting-autopilot](https://github.com/openclaw/skills/tree/main/skills/tkuehnl/meeting-autopilot/SKILL.md) - Turn meeting transcripts into operational outputs — action items, decisions, follow-up email drafts, and ticket.
 - [meeting-summarizer](https://github.com/openclaw/skills/tree/main/skills/claudiodrusus/meeting-summarizer/SKILL.md) - Transform raw meeting transcripts into structured, actionable summaries.


### PR DESCRIPTION
## Summary

- Adds [brunobuddy/manifest-build](https://github.com/openclaw/skills/tree/main/skills/brunobuddy/manifest-build/SKILL.md) to the **AI & LLMs** category
- Open-source LLM routing and cost tracking plugin — routes requests to optimal models via a scoring algorithm, with real-time cost/token dashboards and spending limits

## Quality checklist

- [x] Skill is published in the official [openclaw/skills](https://github.com/openclaw/skills) repo
- [x] SKILL.md link resolves correctly
- [x] Description is under 10 words (9 words)
- [x] Entry follows the existing list format
- [x] Placed in alphabetical order within the AI & LLMs category
- [x] No duplicate entry exists
- [x] Skill count updated in category file and README