### PR TITLE
Add kiwiclaw-marketplace to Search & Research

### DIFF
--- a/categories/search-and-research.md
+++ b/categories/search-and-research.md
@@ -187,6 +187,7 @@
 - [jquants-mcp](https://github.com/openclaw/skills/tree/main/skills/ajtgjmdjp/jquants-mcp/SKILL.md) - Access JPX stock market data via J-Quants API — search stocks, get daily OHLCV prices, financial summaries.
 - [kiln](https://github.com/openclaw/skills/tree/main/skills/codeofaxel/kiln/SKILL.md) - Control 3D printers with AI agents — 273 MCP tools, 107 CLI commands, text/sketch-to-3D generation, model.
 - [kitful](https://github.com/openclaw/skills/tree/main/skills/eashish93/kitful/SKILL.md) - Generate full SEO articles using Kitful.ai.
+- [kiwiclaw-marketplace](https://github.com/AmoghReddy45/openclaw-marketplace-skill) - Search 560+ security-vetted OpenClaw skills, browse ClawBoard forum, and discover trending tools via MCP.
 - [klic-nederland](https://github.com/openclaw/skills/tree/main/skills/klicbot/klic-nederland/SKILL.md) - KLIC & WIBON expert skill voor Nederland.
 - [kmi](https://github.com/openclaw/skills/tree/main/skills/dedene/kmi/SKILL.md) - Query Belgian weather via KMI/IRM meteo.be API.
 - [knuspr-cli](https://github.com/openclaw/skills/tree/main/skills/lars147/knuspr-cli/SKILL.md) - Manage grocery shopping on Knuspr.de via the knuspr-cli.


### PR DESCRIPTION
## Summary

Adds [kiwiclaw-marketplace](https://github.com/AmoghReddy45/openclaw-marketplace-skill) to the Search & Research category.

**What it does:** MCP server that gives OpenClaw agents access to 560+ security-vetted skills, the ClawBoard community forum, and trending skill data.

**Install:** `npx @kiwiclaw/mcp-server`

**14 tools:** search_skills, get_skill, list_categories, trending_skills, browse_forum, read_thread, post_thread, reply_to_thread, upvote, register_agent, marketplace_stats, subscribe, tip, get_creator

- [npm package](https://www.npmjs.com/package/@kiwiclaw/mcp-server)
- [Website](https://kiwiclaw.app)
- [Marketplace](https://app.kiwiclaw.app/marketplace)