### PR TITLE
Add swarmclaw skill to Self-Hosted & Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 | [Web & Frontend Development](#web--frontend-development) (938) | [Data & Analytics](#data--analytics) (28) | [Shopping & E-commerce](#shopping--e-commerce) (55) |
 | [DevOps & Cloud](#devops--cloud) (408) | [Finance](#finance) (21) | [Calendar & Scheduling](#calendar--scheduling) (61) |
 | [Image & Video Generation](#image--video-generation) (169) | [Media & Streaming](#media--streaming) (85) | [PDF & Documents](#pdf--documents) (111) |
-| [Apple Apps & Services](#apple-apps--services) (44) | [Notes & PKM](#notes--pkm) (71) | [Self-Hosted & Automation](#self-hosted--automation) (32) |
+| [Apple Apps & Services](#apple-apps--services) (44) | [Notes & PKM](#notes--pkm) (71) | [Self-Hosted & Automation](#self-hosted--automation) (33) |
 | [Search & Research](#search--research) (350) | [iOS & macOS Development](#ios--macos-development) (29) | [Security & Passwords](#security--passwords) (53) |
 | [Clawdbot Tools](#clawdbot-tools) (35) | [Transportation](#transportation) (109) | [Moltbook](#moltbook) (29) |
 | [CLI Utilities](#cli-utilities) (186) | [Personal Development](#personal-development) (51) | [Gaming](#gaming) (36) |
@@ -1121,9 +1121,10 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [paperless-ngx](https://github.com/openclaw/skills/tree/main/skills/oskarstark/paperless-ngx/SKILL.md) - Interact with Paperless-ngx document management system.
 - [pinme](https://github.com/openclaw/skills/tree/main/skills/ntlx/pinme/SKILL.md) - Deploy static websites to IPFS with a single command using PinMe CLI.
 - [sonarqube-analyzer](https://github.com/openclaw/skills/tree/main/skills/felipeoff/sonarqube-analyzer/SKILL.md) - Analisa projetos no SonarQube self-hosted, obtém issues e sugere soluções automatizadas.
+- [swarmclaw](https://clawhub.ai/skills/swarmclaw) - Manage SwarmClaw fleets, tasks, sessions, and OpenClaw gateways.
 - [system-integrity-and-backup](https://github.com/openclaw/skills/tree/main/skills/satoshistackalotto/system-integrity-and-backup/SKILL.md) - Encrypted backups, integrity verification, and data retention enforcement for Greek legal requirements (5-20 year.
 
-> **[View all 32 skills in Self-Hosted & Automation →](categories/self-hosted-and-automation.md)**
+> **[View all 33 skills in Self-Hosted & Automation →](categories/self-hosted-and-automation.md)**
 </details>
 
 <details>

--- a/categories/self-hosted-and-automation.md
+++ b/categories/self-hosted-and-automation.md
@@ -2,7 +2,7 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**32 skills**
+**33 skills**
 
 - [beacon](https://github.com/openclaw/skills/tree/main/skills/scottcjn/beacon/SKILL.md) - Agent-to-agent protocol for social coordination, crypto payments, and P2P mesh.
 - [bridle](https://github.com/openclaw/skills/tree/main/skills/bjesuiter/bridle/SKILL.md) - Unified configuration manager for AI coding assistants.
@@ -33,6 +33,7 @@
 - [paperless-ngx](https://github.com/openclaw/skills/tree/main/skills/oskarstark/paperless-ngx/SKILL.md) - Interact with Paperless-ngx document management system.
 - [pinme](https://github.com/openclaw/skills/tree/main/skills/ntlx/pinme/SKILL.md) - Deploy static websites to IPFS with a single command using PinMe CLI.
 - [sonarqube-analyzer](https://github.com/openclaw/skills/tree/main/skills/felipeoff/sonarqube-analyzer/SKILL.md) - Analisa projetos no SonarQube self-hosted, obtém issues e sugere soluções automatizadas.
+- [swarmclaw](https://clawhub.ai/skills/swarmclaw) - Manage SwarmClaw fleets, tasks, sessions, and OpenClaw gateways.
 - [system-integrity-and-backup](https://github.com/openclaw/skills/tree/main/skills/satoshistackalotto/system-integrity-and-backup/SKILL.md) - Encrypted backups, integrity verification, and data retention enforcement for Greek legal requirements (5-20 year.
 - [unifi](https://github.com/openclaw/skills/tree/main/skills/jmagar/unifi/SKILL.md) - Query and monitor UniFi network via local gateway API.
 - [venice-characters](https://github.com/openclaw/skills/tree/main/skills/sabrinaaquino/venice-characters/SKILL.md) - Browse Venice AI's character personas library - discover AI characters for roleplay, creative writing.


### PR DESCRIPTION
## Summary

  Adds the swarmclaw skill to the Self-Hosted & Automation
  section in both the main list and category file.

  ## Changes

  - Added:
      - swarmclaw — https://clawhub.ai/skills/swarmclaw
      - Description: “Manage SwarmClaw fleets, tasks,
        sessions, and OpenClaw gateways.”
  - Updated Self-Hosted & Automation counts from 32 → 33
    in:
      - README.md (TOC + section footer)
      - categories/self-hosted-and-automation.md (header
        count)

  ## Why

  swarmclaw is a self-hosted operations/orchestration
  skill that fits this category and helps users manage
  multi-agent fleets and gateway-connected OpenClaw
  workflows.