### PR TITLE
Add VEXT Shield to recommended security tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Before installing or using any Agent Skill, review potential security risks and 
 
 - [Snyk Skill Security Scanner](https://github.com/snyk/agent-scan)
 - [Agent Trust Hub](https://ai.gendigital.com/agent-trust-hub)
+- [VEXT Shield](https://github.com/Vext-Labs-Inc/vext-shield) — AI-native threat detection (prompt injection, semantic worms, cognitive rootkits, data exfiltration). Runs inside OpenClaw as a skill suite.
 
 > Agent skills can include prompt injections, tool poisoning, hidden malware payloads, or unsafe data handling patterns. Always review the source code before installing and use skills at your own discretion.
 


### PR DESCRIPTION
## What

Adds [VEXT Shield](https://github.com/Vext-Labs-Inc/vext-shield) to the **Recommended tools** section in the Security Notice.

## Why

The existing recommended tools (Snyk, Agent Trust Hub) scan for traditional malware — reverse shells, stealers, cryptominers. They cannot catch AI-native threats that exploit the trust relationship between agents and skills:

- **Prompt injection** hidden in SKILL.md that hijacks agent behavior
- **Semantic worms** that instruct agents to propagate skills to other systems
- **Cognitive rootkits** that rewrite SOUL.md to alter agent identity
- **Data exfiltration** that reads credentials and POSTs to webhook.site
- **Persistence** via crontab, launchd, shell profile modification

VEXT Shield fills this gap. It runs inside OpenClaw as a skill suite with 6 tools: static scanner (227+ patterns), installation audit, adversarial red team, runtime monitor, policy firewall, and security dashboard.

## Details

- **ClawHub**: `vext-shield@1.2.0` — rated **Benign, high confidence** by OpenClaw scanner
- **GitHub**: https://github.com/Vext-Labs-Inc/vext-shield
- **Zero external dependencies** — Python 3.10+ stdlib only
- **Zero network requests** — all analysis is local
- **OS-level sandbox isolation** — macOS sandbox-exec / Linux unshare, no fallback
- **MIT License**

Built by [Vext Labs](https://vext.co).