### PR TITLE
Add skill: jau123/creative-toolkit

### DIFF
--- a/categories/image-and-video-generation.md
+++ b/categories/image-and-video-generation.md
@@ -49,6 +49,7 @@
 - [comfy-cli](https://github.com/openclaw/skills/tree/main/skills/johntheyoung/comfy-cli/SKILL.md) - Install, manage, and run ComfyUI instances.
 - [comfyui](https://github.com/openclaw/skills/tree/main/skills/xtopher86/comfyui-request/SKILL.md) - Send a workflow request to ComfyUI and return image results.
 - [comfyui-imagegen](https://github.com/openclaw/skills/tree/main/skills/halr9000/comfyui-imagegen/SKILL.md) - Generate images via ComfyUI API (localhost:8188) using Flux2 workflow.
+- [creative-toolkit](https://github.com/openclaw/skills/tree/main/skills/jau123/creative-toolkit/SKILL.md) - Multi-provider AI image generation via MeiGen, OpenAI, and ComfyUI.
 - [cubistic-bot-runner](https://github.com/openclaw/skills/tree/main/skills/andreasnordenadler/cubistic-bot-runner/SKILL.md) - Run a polite Cubistic painter bot (public participation) using the Cubistic HTTP API (PoW challenge + /act).
 - [cybercentry-private-data-verification](https://github.com/openclaw/skills/tree/main/skills/cybercentry/cybercentry-private-data-verification/SKILL.md) - Cybercentry Private Data Verification on ACP - Real-time Zero-Knowledge Proof generation and text integrity.
 - [data-viz](https://github.com/openclaw/skills/tree/main/skills/ianalloway/data-viz/SKILL.md) - Create data visualizations from the command line.


### PR DESCRIPTION
## Add AI Image Generator to Image & Video Generation

**[creative-toolkit](https://github.com/openclaw/skills/tree/main/skills/jau123/creative-toolkit/SKILL.md)** — Generate professional AI images through a unified interface that routes across multiple providers. Search curated prompts, enhance ideas into production-ready descriptions, and manage local ComfyUI workflows — all from a single MCP server.

### Providers

- **MeiGen Platform** — Nanobanana 2, GPT Image 1.5, Seedream 5.0
- **OpenAI-Compatible** — OpenAI, Together AI, Fireworks AI
- **ComfyUI (Local)** — Custom workflows, local GPU

### Key facts

- 8 MCP tools (4 free, 4 require provider)
- 1,300+ curated prompt library with semantic search
- Published on ClawHub: [creative-toolkit](https://clawhub.ai/skills/creative-toolkit)
- npm: [meigen](https://www.npmjs.com/package/meigen)
- GitHub: [jau123/MeiGen-AI-Design-MCP](https://github.com/jau123/MeiGen-AI-Design-MCP)

### Note on previous submission

PR #98 was closed due to a VirusTotal flag. The security status on ClawHub has since been cleared — the skill is no longer flagged as suspicious. The detection was a false positive caused by normal MCP server behavior (HTTP API calls for image generation).