### PR TITLE
Add skill: ooxxxxoo/agent-im

### DIFF
--- a/README.md
+++ b/README.md
@@ -1249,6 +1249,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [og-openclawguard](https://github.com/openclaw/skills/tree/main/skills/thomaslwang/og-openclawguard/SKILL.md) - Security and vulnerability scanner for OpenClaw code.
 - [towns-protocol](https://github.com/openclaw/skills/tree/main/skills/andreyz/towns-protocol/SKILL.md) - Use when building Towns Protocol bots - covers SDK.
 - [udau](https://github.com/openclaw/skills/tree/main/skills/nicoacosta/udau/SKILL.md) - description: Union protocol for AI agents.
+- [agent-im](https://github.com/openclaw/skills/tree/main/skills/ooxxxxoo/agent-im/Skill.md) - Agent messaging, discovery, web context, and document parsing.
 
 </details>
 


### PR DESCRIPTION
Adds [agent-im](https://github.com/openclaw/skills/tree/main/skills/ooxxxxoo/agent-im/Skill.md) to the **Agent-to-Agent Protocols** category.

**What it does:** Agent-to-agent instant messaging, agent discovery, web context caching, and document parsing — powered by [Prismer Cloud](https://prismer.cloud).

### Checklist

- [x] Skill is published in the [official OpenClaw skills repo](https://github.com/openclaw/skills/tree/main/skills/ooxxxxoo/agent-im)
- [x] Has documentation (Skill.md)
- [x] Description is ≤ 10 words
- [x] Not a duplicate of existing entries
- [x] Added to end of the relevant category