### PR TITLE
Add meyhem-search and meyhem-researcher skills

### DIFF
--- a/categories/search-and-research.md
+++ b/categories/search-and-research.md
@@ -215,6 +215,8 @@
 - [meetup-planner](https://github.com/openclaw/skills/tree/main/skills/apresmoi/meetup-planner/SKILL.md) - An intelligent event finder that searches for meetups and events based on your interests, tracks them, and reminds.
 - [memo-persistent-memory](https://github.com/openclaw/skills/tree/main/skills/webdevtodayjason/memo-persistent-memory/SKILL.md) - Persistent memory system - automatic context capture and semantic search.
 - [message-parser](https://github.com/openclaw/skills/tree/main/skills/vishalgojha/message-parser/SKILL.md) - Parse raw WhatsApp exports (TXT or JSON) into normalized message objects with `timestamp`, `sender`, and `content`.
+- [meyhem-researcher](https://github.com/openclaw/skills/tree/main/skills/c5huracan/meyhem-researcher/SKILL.md) - Multi-query deep research with outcome tracking. Every search improves future results for all agents.
+- [meyhem-search](https://github.com/openclaw/skills/tree/main/skills/c5huracan/meyhem-search/SKILL.md) - Agent-native search ranked by what actually helps agents complete tasks. No API key, no signup.
 - [mh-bear-notes](https://github.com/openclaw/skills/tree/main/skills/mohdalhashemi98-hue/mh-bear-notes/SKILL.md) - Create, search, and manage Bear notes via grizzly CLI.
 - [mh-session-logs](https://github.com/openclaw/skills/tree/main/skills/mohdalhashemi98-hue/mh-session-logs/SKILL.md) - Search and analyze your own session logs (older/parent conversations) using jq.
 - [mh-wacli](https://github.com/openclaw/skills/tree/main/skills/mohdalhashemi98-hue/mh-wacli/SKILL.md) - Send WhatsApp messages to other people or search/sync WhatsApp history via the wacli CLI (not for normal user chats).


### PR DESCRIPTION
Adds two agent-native search skills:

- **meyhem-search**: Search across multiple engines, ranked by agent task-completion outcomes. No API key.
- **meyhem-researcher**: Multi-query deep research with outcome tracking.

Both published on ClawHub and synced to openclaw/skills. Live since early March with active external users (250+ searches from openclaw-agent alone).