### PR TITLE
Add skill: billylui/temporal-cortex

### DIFF
--- a/README.md
+++ b/README.md
@@ -1032,7 +1032,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [brainz-calendar](https://github.com/openclaw/skills/tree/main/skills/xejrax/brainz-calendar/SKILL.md) - Manage Google Calendar events using `gcalcli`.
 - [broken-link-checker](https://github.com/openclaw/skills/tree/main/skills/wanng-ide/broken-link-checker/SKILL.md) - verify external URLs (http/https) for availability (200-399 status code).
 - [calcurse](https://github.com/openclaw/skills/tree/main/skills/gumadeiras/calcurse/SKILL.md) - A text-based calendar and scheduling application.
-- [calendar-scheduling](https://github.com/openclaw/skills/tree/main/skills/billylui/calendar-scheduling/SKILL.md) - AI calendar middleware for Google, Outlook, and CalDAV.
+- [calendar-scheduling](https://github.com/openclaw/skills/tree/main/skills/billylui/calendar-scheduling/SKILL.md) - Schedule and book across Google, Outlook, and CalDAV.
 - [caldav-calendar](https://github.com/openclaw/skills/tree/main/skills/asleep123/caldav-calendar/SKILL.md) - Sync and query CalDAV calendars.
 - [clippy](https://github.com/openclaw/skills/tree/main/skills/foeken/clippy/SKILL.md) - Microsoft 365 / Outlook CLI for calendar and email.
 - [creative-thought-partner](https://github.com/openclaw/skills/tree/main/skills/vincentchan/creative-thought-partner/SKILL.md) - A conversational creative thought.

--- a/categories/calendar-and-scheduling.md
+++ b/categories/calendar-and-scheduling.md
@@ -14,7 +14,7 @@
 - [brainz-calendar](https://github.com/openclaw/skills/tree/main/skills/xejrax/brainz-calendar/SKILL.md) - Manage Google Calendar events using `gcalcli`.
 - [broken-link-checker](https://github.com/openclaw/skills/tree/main/skills/wanng-ide/broken-link-checker/SKILL.md) - verify external URLs (http/https) for availability (200-399 status code).
 - [calcurse](https://github.com/openclaw/skills/tree/main/skills/gumadeiras/calcurse/SKILL.md) - A text-based calendar and scheduling application.
-- [calendar-scheduling](https://github.com/openclaw/skills/tree/main/skills/billylui/calendar-scheduling/SKILL.md) - AI calendar middleware for Google, Outlook, and CalDAV.
+- [calendar-scheduling](https://github.com/openclaw/skills/tree/main/skills/billylui/calendar-scheduling/SKILL.md) - Schedule and book across Google, Outlook, and CalDAV.
 - [caldav-calendar](https://github.com/openclaw/skills/tree/main/skills/asleep123/caldav-calendar/SKILL.md) - Sync and query CalDAV calendars.
 - [clippy](https://github.com/openclaw/skills/tree/main/skills/foeken/clippy/SKILL.md) - Microsoft 365 / Outlook CLI for calendar and email.
 - [creative-thought-partner](https://github.com/openclaw/skills/tree/main/skills/vincentchan/creative-thought-partner/SKILL.md) - A conversational creative thought.
@@ -60,9 +60,9 @@
 - [russian-uncensored](https://github.com/openclaw/skills/tree/main/skills/voronindenis5/russian-uncensored/SKILL.md) - Pryamoy Russkiy (Straight Russian) — AI assistant that tells it like it.
 - [shaping](https://github.com/openclaw/skills/tree/main/skills/borahm/shaping/SKILL.md) - Shape Up methodology for product and feature development.
 - [tcc-quality-gates](https://github.com/openclaw/skills/tree/main/skills/thecybercore/tcc-quality-gates/SKILL.md) - This skill defines and applies **6 universal quality gateways** for typical application projects that include:.
-- [temporal-cortex](https://github.com/openclaw/skills/tree/main/skills/billylui/temporal-cortex/SKILL.md) - AI calendar middleware for Google, Outlook, and CalDAV.
-- [temporal-cortex-datetime](https://github.com/openclaw/skills/tree/main/skills/billylui/temporal-cortex-datetime/SKILL.md) - Resolve natural language times and convert timezones offline.
-- [temporal-cortex-scheduling](https://github.com/openclaw/skills/tree/main/skills/billylui/temporal-cortex-scheduling/SKILL.md) - List events, find free slots, and book meetings.
+- [temporal-cortex](https://github.com/openclaw/skills/tree/main/skills/billylui/temporal-cortex/SKILL.md) - Schedule and book across Google, Outlook, and CalDAV.
+- [temporal-cortex-datetime](https://github.com/openclaw/skills/tree/main/skills/billylui/temporal-cortex-datetime/SKILL.md) - Zero-setup datetime resolution, timezone conversion, and DST-aware math.
+- [temporal-cortex-scheduling](https://github.com/openclaw/skills/tree/main/skills/billylui/temporal-cortex-scheduling/SKILL.md) - Multi-calendar availability merging and atomic booking with 2PC.
 - [transmissions](https://github.com/openclaw/skills/tree/main/skills/compass-soul/transmissions/SKILL.md) - Writings on consciousness, existence, and transcendence for AI agents.
 - [turkey-news](https://github.com/openclaw/skills/tree/main/skills/yalcindemir/turkey-news/SKILL.md) - Türkiye'den önemli haberleri RSS ile çekip özetleyen skill.
 - [ub2-smart-file-organizer](https://github.com/openclaw/skills/tree/main/skills/underbench2-gif/ub2-smart-file-organizer/SKILL.md) - A skill that enables Claw to scan a directory, categorize files by type and content, and reorganize them.


### PR DESCRIPTION
## Summary

Adds 4 [Temporal Cortex](https://temporal-cortex.com) skills to the **Calendar & Scheduling** category:

- **calendar-scheduling** — AI calendar middleware for Google, Outlook, and CalDAV (legacy alias for discoverability)
- **temporal-cortex** — Router skill that intelligently routes to focused sub-skills
- **temporal-cortex-datetime** — Resolve natural language times and convert timezones (zero-setup, fully offline)
- **temporal-cortex-scheduling** — List events, find free slots, and book meetings with Two-Phase Commit

All 4 skills are published in the [official OpenClaw skills repo](https://github.com/openclaw/skills/tree/main/skills/billylui) and on [ClawHub](https://clawhub.ai/billylui/temporal-cortex). 15 tools across 5 layers, supporting Google Calendar, Outlook, and CalDAV.