### PR TITLE
Add skill: awsome-o/grafana-lens

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 | [Coding Agents & IDEs](#coding-agents--ides) (1222) | [Productivity & Tasks](#productivity--tasks) (206) | [Speech & Transcription](#speech--transcription) (45) |
 | [Browser & Automation](#browser--automation) (335) | [AI & LLMs](#ai--llms) (197) | [Smart Home & IoT](#smart-home--iot) (43) |
 | [Web & Frontend Development](#web--frontend-development) (938) | [Data & Analytics](#data--analytics) (28) | [Shopping & E-commerce](#shopping--e-commerce) (55) |
-| [DevOps & Cloud](#devops--cloud) (408) | [Finance](#finance) (21) | [Calendar & Scheduling](#calendar--scheduling) (65) |
+| [DevOps & Cloud](#devops--cloud) (409) | [Finance](#finance) (21) | [Calendar & Scheduling](#calendar--scheduling) (65) |
 | [Image & Video Generation](#image--video-generation) (169) | [Media & Streaming](#media--streaming) (85) | [PDF & Documents](#pdf--documents) (111) |
 | [Apple Apps & Services](#apple-apps--services) (44) | [Notes & PKM](#notes--pkm) (71) | [Self-Hosted & Automation](#self-hosted--automation) (32) |
 | [Search & Research](#search--research) (350) | [iOS & macOS Development](#ios--macos-development) (29) | [Security & Passwords](#security--passwords) (53) |

--- a/categories/devops-and-cloud.md
+++ b/categories/devops-and-cloud.md
@@ -2,7 +2,7 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**408 skills**
+**409 skills**
 
 - [0x0-messenger](https://github.com/openclaw/skills/tree/main/skills/eijiac24/0x0-messenger/SKILL.md) - Send and receive P2P messages using disposable numbers and PINs.
 - [12306](https://github.com/openclaw/skills/tree/main/skills/kirorab/12306/SKILL.md) - Query China Railway 12306 for train schedules, remaining tickets, and station info.
@@ -181,6 +181,7 @@
 - [gmail-oauth](https://github.com/openclaw/skills/tree/main/skills/kai-jar/gmail-oauth/SKILL.md) - Set up Gmail API access via gog CLI with manual OAuth flow.
 - [gmail-tool](https://github.com/openclaw/skills/tree/main/skills/junkaixue/gmail-tool/SKILL.md) - Send and read emails via Gmail using App Password.
 - [gradient-inference](https://github.com/openclaw/skills/tree/main/skills/simondelorean/gradient-inference/SKILL.md) - Community skill (unofficial) for DigitalOcean Gradient AI Serverless Inference.
+- [grafana-lens](https://github.com/openclaw/skills/tree/main/skills/awsome-o/grafana-lens/SKILL.md) - Full Grafana access: query, dashboard, alert, trace — 16 agent tools.
 - [grafana-plugin](https://github.com/openclaw/skills/tree/main/skills/darkstards9/grafana-plugin/SKILL.md) - Read current values from Grafana dashboards without knowing the underlying queries.
 - [graphthulhu](https://github.com/openclaw/skills/tree/main/skills/skridlevsky/graphthulhu/SKILL.md) - Knowledge graph MCP server for Logseq and Obsidian. 37 tools for reading, writing, searching, and analyzing.
 - [greek-document-ocr](https://github.com/openclaw/skills/tree/main/skills/satoshistackalotto/greek-document-ocr/SKILL.md) - Greek-language OCR using Tesseract.


### PR DESCRIPTION
## Add skill: awsome-o/grafana-lens

**Category:** DevOps & Cloud

Full Grafana integration for OpenClaw agents — 16 composable tools for PromQL/LogQL/TraceQL queries, dashboard creation & management, alerting, security monitoring, and custom metrics push.

**Why it belongs here:**
- Published on npm as `openclaw-grafana-lens` with active usage
- Covers the full Grafana workflow: query → dashboard → alert → share → annotate → trace
- 12 pre-built dashboard templates (AI observability, SRE, security)
- Full OTLP observability pipeline (metrics → Prometheus, logs → Loki, traces → Tempo)
- Security monitoring: prompt injection detection, tool loop detection, cost anomalies

**Not a duplicate:** Existing `grafana-plugin` and `rpe-grafana` (by darkstards9) are read-only with 3 tools. Grafana Lens provides full read/write/alert/trace access with 16 tools.

**Published at:** https://github.com/openclaw/skills/tree/main/skills/awsome-o/grafana-lens/SKILL.md