### PR TITLE
Add skill: c-joey/provider-sync, telegram-footer-patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 | [Image & Video Generation](#image--video-generation) (169) | [Media & Streaming](#media--streaming) (85) | [PDF & Documents](#pdf--documents) (111) |
 | [Apple Apps & Services](#apple-apps--services) (44) | [Notes & PKM](#notes--pkm) (71) | [Self-Hosted & Automation](#self-hosted--automation) (32) |
 | [Search & Research](#search--research) (350) | [iOS & macOS Development](#ios--macos-development) (29) | [Security & Passwords](#security--passwords) (53) |
-| [Clawdbot Tools](#clawdbot-tools) (36) | [Transportation](#transportation) (109) | [Moltbook](#moltbook) (29) |
+| [Clawdbot Tools](#clawdbot-tools) (37) | [Transportation](#transportation) (109) | [Moltbook](#moltbook) (29) |
 | [CLI Utilities](#cli-utilities) (186) | [Personal Development](#personal-development) (51) | [Gaming](#gaming) (36) |
 | [Health & Fitness](#health--fitness) (88) | [Agent-to-Agent Protocols](#agent-to-agent-protocols) (17) | |
 
@@ -460,9 +460,8 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [clawdefender](https://github.com/openclaw/skills/tree/main/skills/nukewire/clawdefender/SKILL.md) - Security scanner and input sanitizer for AI agents.
 - [clawdirect](https://github.com/openclaw/skills/tree/main/skills/napoleond/clawdirect/SKILL.md) - Interact with ClawDirect, a directory of social web experiences.
 - [clawdirect-dev](https://github.com/openclaw/skills/tree/main/skills/napoleond/clawdirect-dev/SKILL.md) - Build agent-facing web experiences with ATXP-based.
-- [c-joey](https://github.com/openclaw/skills/tree/main/skills/c-joey) - OpenClaw maintenance skills: provider sync and Telegram footer patching.
 
-> **[View all 36 skills in Clawdbot Tools →](categories/clawdbot-tools.md)**
+> **[View all 37 skills in Clawdbot Tools →](categories/clawdbot-tools.md)**
 </details>
 
 <details>

--- a/categories/clawdbot-tools.md
+++ b/categories/clawdbot-tools.md
@@ -2,7 +2,7 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**36 skills**
+**37 skills**
 
 - [adhd-assistant](https://github.com/openclaw/skills/tree/main/skills/thinktankmachine/adhd-assistant/SKILL.md) - ADHD-friendly life management assistant for OpenClaw.
 - [adhd-ssistant](https://github.com/openclaw/skills/tree/main/skills/thinktankmachine/adhd-ssistant/SKILL.md) - ADHD-friendly life management assistant for OpenClaw.
@@ -37,5 +37,6 @@
 - [mcp-hass](https://github.com/openclaw/skills/tree/main/skills/al-one/mcp-hass/SKILL.md) - The skill for control Home Assistant smart home devices and query states using MCP protocol.
 - [meegle-mcp-skill](https://github.com/openclaw/skills/tree/main/skills/pkycy/meegle-mcp-skill/SKILL.md) - Interact with Meegle project management system via MCP protocol.
 - [pipedream-connect](https://github.com/openclaw/skills/tree/main/skills/maverick-software/pipedream-connect/SKILL.md) - Connect 2,000+ APIs with managed OAuth via Pipedream.
+- [provider-sync](https://github.com/openclaw/skills/tree/main/skills/c-joey/provider-sync/SKILL.md) - Sync provider models into OpenClaw config.
+- [telegram-footer-patch](https://github.com/openclaw/skills/tree/main/skills/c-joey/telegram-footer-patch/SKILL.md) - Patch Telegram replies with OpenClaw footer.
 - [zapier-mcp](https://github.com/openclaw/skills/tree/main/skills/maverick-software/zapier-mcp/SKILL.md) - Connect 8,000+ apps via Zapier MCP.
-- [c-joey](https://github.com/openclaw/skills/tree/main/skills/c-joey) - OpenClaw maintenance skills: provider sync and Telegram footer patching.


### PR DESCRIPTION
## Skills Added

Two OpenClaw utility skills from [c-joey](https://github.com/openclaw/skills/tree/main/skills/c-joey):

### 1. [provider-sync](https://github.com/openclaw/skills/tree/main/skills/c-joey/provider-sync/SKILL.md)
Sync provider models into OpenClaw config.

### 2. [telegram-footer-patch](https://github.com/openclaw/skills/tree/main/skills/c-joey/telegram-footer-patch/SKILL.md)
Patch Telegram replies with OpenClaw footer.

### Category
Both added to **Clawdbot Tools** (alphabetical order).

### Checklist
- [x] All skills published in official OpenClaw skills repo
- [x] Each has SKILL.md documentation
- [x] Descriptions under 10 words
- [x] Not crypto/finance related
- [x] Not duplicates of existing entries
