### PR TITLE
Add skill: kriptoburak/xquik-x-twitter-scraper

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [ai-review](https://github.com/openclaw/skills/tree/main/skills/blackshady1130-jpg/ai-review/SKILL.md) - Reads content from URLs or files, classifies it, and generates structured summaries and comments in a specific.
 - [aihotel](https://github.com/openclaw/skills/tree/main/skills/qiao101660/aihotel/SKILL.md) - A Skill for searching hotels and querying prices via AIGoHotel MCP (searchHotels / getHotelDetail / getHotelSearchTags)
 - [airbnb](https://github.com/openclaw/skills/tree/main/skills/stveenli/airbnb/SKILL.md) - Search Airbnb listings with prices, ratings, and direct links.
+- [xquik-x-twitter-scraper](https://github.com/openclaw/skills/tree/main/skills/kriptoburak/xquik-x-twitter-scraper/SKILL.md) - X API scraper with 40+ tools for AI agents.
 
 > **[View all 350 skills in Search & Research →](categories/search-and-research.md)**
 </details>

--- a/categories/search-and-research.md
+++ b/categories/search-and-research.md
@@ -357,3 +357,4 @@
 - [zvukogram](https://github.com/openclaw/skills/tree/main/skills/erview/zvukogram/SKILL.md) - Text-to-Speech via Zvukogram API with SSML support.
 - [zynd-network](https://github.com/openclaw/skills/tree/main/skills/atmegabuzz/zynd-network/SKILL.md) - Connect to the Zynd AI Network to discover, communicate with, and pay other AI agents.
 - [aminer-open-academic](https://github.com/openclaw/skills/tree/main/skills/canxiangcc/aminer-open-academic/SKILL.md) - AMiner open academic resource query tool and academic data acquisition tool.
+- [xquik-x-twitter-scraper](https://github.com/openclaw/skills/tree/main/skills/kriptoburak/xquik-x-twitter-scraper/SKILL.md) - X API scraper with 40+ tools for AI agents.


### PR DESCRIPTION
## Summary

Add xquik-x-twitter-scraper to the Search & Research category.

X API scraper with 40+ extraction, monitoring, and automation tools designed for AI agents. Covers tweets, replies, followers, lists, search, trends, and more.

## Links

- **ClawHub**: https://clawhub.com/kriptoburak/xquik-x-twitter-scraper
- **GitHub**: https://github.com/Xquik-dev/x-twitter-scraper