### PR TITLE
Add skill: yys2024/creaa-ai

### DIFF
--- a/categories/image-and-video-generation.md
+++ b/categories/image-and-video-generation.md
@@ -2,7 +2,7 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**169 skills**
+**170 skills**
 
 - [aada](https://github.com/openclaw/skills/tree/main/skills/rylena/aada/SKILL.md) - Create and send fun, personality-rich promotional messages from one agent to the Moltbook audience.
 - [ace-music](https://github.com/openclaw/skills/tree/main/skills/fspecii/ace-music/SKILL.md) - Generate AI music using ACE-Step 1.5 via ACE Music's free API.
@@ -175,3 +175,4 @@
 - [zenmux-image-generation](https://github.com/openclaw/skills/tree/main/skills/dadaniya99/zenmux-image-generation/SKILL.md) - Generate images via ZenMux API (Pro/Elite)
 - [zerox](https://github.com/openclaw/skills/tree/main/skills/otacu/zerox/SKILL.md) - Convert documents (PDF, DOCX, PPTX, images, etc.) to Markdown using the zerox library.
 - [zhipu-cogview-image](https://github.com/openclaw/skills/tree/main/skills/honestqiao/zhipu-cogview-image/SKILL.md) - Generate images using Zhipu AI's CogView model.
+- [creaa-ai](https://github.com/openclaw/skills/tree/main/skills/yys2024/creaa-ai/SKILL.md) - Generate and edit images + generate videos via Creaa API (Nano Banana 2, Sora 2, Seedance 2.0, Veo 3.1).


### PR DESCRIPTION
## New Skill: creaa-ai by yys2024

- **ClawHub:** https://clawhub.ai/yys2024/creaa-ai
- **GitHub (openclaw/skills PR):** https://github.com/openclaw/skills/pull/176

## What it does

Creaa AI is the first AI image+video generation skill officially published on ClawHub.

- **Image generation**: Nano Banana 2, Seedream 4.5, GPT Image 1.5, Z-Image Turbo
- **Image editing**: Single image edit, multi-image composition (up to 14 ref images)
- **Video generation**: Sora 2, Sora 2 Pro, Seedance 2.0, Veo 3.1, Kling 3.0, Runway Gen-4.5
- **Image-to-video**: Animate still images into video

## Category

Image & Video Generation

## Install

```bash
npx clawhub install creaa-ai
```