### PR TITLE
Add skill: varsmallrookie/bluente-translate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1060,6 +1060,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [competitor-analyzer](https://github.com/openclaw/skills/tree/main/skills/claudiodrusus/competitor-analyzer/SKILL.md) - Analyze any company's competitive position in minutes.
 - [confidant](https://github.com/openclaw/skills/tree/main/skills/ericsantos/confidant/SKILL.md) - Secure secret handoff from human to AI.
 - [confluence](https://github.com/openclaw/skills/tree/main/skills/francisbrero/confluence/SKILL.md) - Search and manage Confluence pages and spaces using confluence-cli.
+- [bluente-translate](https://github.com/openclaw/skills/blob/main/skills/varsmallrookie/bluente-translate/SKILL.md) - Translate your documents with formatting intact in 2 minutes.
 
 > **[View all 111 skills in PDF & Documents →](categories/pdf-and-documents.md)**
 </details>

--- a/categories/pdf-and-documents.md
+++ b/categories/pdf-and-documents.md
@@ -115,3 +115,4 @@
 - [x-to-kindle](https://github.com/openclaw/skills/tree/main/skills/brianlu365ai/x-to-kindle/SKILL.md) - Send X/Twitter posts to Kindle for distraction-free reading.
 - [xapi-labs](https://github.com/openclaw/skills/tree/main/skills/glacier-luo/xapi-labs/SKILL.md) - Aggregated API platform for AI agents.
 - [xapi123123](https://github.com/openclaw/skills/tree/main/skills/glacier-luo/xapi123123/SKILL.md) - Aggregated API platform for AI agents.
+- [bluente-translate](https://github.com/openclaw/skills/blob/main/skills/varsmallrookie/bluente-translate/SKILL.md) - Translate your documents with formatting intact in 2 minutes.


### PR DESCRIPTION
## Skill Information
- Author: varsmallrookie
- Skill name: bluente-translate
- GitHub Link: https://github.com/openclaw/skills/blob/main/skills/varsmallrookie/bluente-translate
- ClawHub Link: https://clawhub.ai/varsmallrookie/bluente-translate
- Description: Translate your documents with formatting intact in 2 minutes

## Checks
- [x] Skill is published in the official OpenClaw skills repo
- [x] SKILL.md exists
- [x] Description is short and clear
- [x] No duplicates
- [x] Not related to crypto/finance
```