### PR TITLE
Add K:BOT — open-source terminal AI agent

### DIFF
--- a/categories/coding-agents-and-ides.md
+++ b/categories/coding-agents-and-ides.md
@@ -550,6 +550,7 @@
 - [judge-human](https://github.com/openclaw/skills/tree/main/skills/drdrewcain/judge-human/SKILL.md) - Vote and submit AI verdicts on ethical, cultural, and content cases alongside human crowds.
 - [jules-api](https://github.com/openclaw/skills/tree/main/skills/arthbhalodiya/jules-api/SKILL.md) - Create and manage Google Jules AI coding sessions via the Jules REST API.
 - [kagi-summarizer](https://github.com/openclaw/skills/tree/main/skills/joelazar/kagi-summarizer/SKILL.md) - Summarize any URL or text using Kagi's Universal Summarizer API.
+- [kbot](https://github.com/isaacsight/kernel/tree/main/packages/kbot/skill/SKILL.md) - Open-source terminal AI agent with 37 specialists, 151 tools, and 19 providers. Learning engine, graph memory, architect mode, offline via Ollama.
 - [keychains](https://github.com/openclaw/skills/tree/main/skills/interagentic/keychains/SKILL.md) - Call any API without leaking credentials.
 - [keychat](https://github.com/openclaw/skills/tree/main/skills/kcdev001/keychat/SKILL.md) - Install Keychat — sovereign E2E encrypted messaging for OpenClaw agents via Signal Protocol over Nostr relays.
 - [keyword-research](https://github.com/openclaw/skills/tree/main/skills/aaron-he-zhu/keyword-research/SKILL.md) - Use when the user asks to "find keywords", "keyword research", "what should I write about", "identify ranking.


### PR DESCRIPTION
## Summary
- Adds K:BOT to the Coding Agents & IDEs category
- K:BOT is an open-source terminal AI agent with 37 specialist agents, 151 tools, and 19 AI providers
- MIT licensed, available on npm (`@kernel.chat/kbot`) and ClawHub (`kbot`)
- Features: learning engine, graph memory, architect mode, confidence calibration, full offline support via Ollama

## Links
- GitHub: https://github.com/isaacsight/kernel
- npm: https://www.npmjs.com/package/@kernel.chat/kbot
- Web: https://kernel.chat

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added kbot, an open-source terminal-based AI agent, to the catalog of available development resources. The agent provides 37 specialists, 151 integrated tools, and comprehensive support across 19 different providers. It features a learning engine, graph memory system, architect mode for handling complex tasks, and offline operation capability via Ollama.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->