### PR TITLE
Add cleanup-reporter skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,7 +523,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [canvas-lms](https://github.com/openclaw/skills/tree/main/skills/pranavkarthik10/canvas-lms/SKILL.md) - Access Canvas LMS (Instructure) for course data, assignments.
 - [captcha-ai](https://github.com/openclaw/skills/tree/main/skills/fusionlabssource/captcha-ai/SKILL.md) - Issue ClawPrint reverse-CAPTCHA challenges to verify.
 
-- [cleanup-reporter](https://github.com/openclaw/skills/tree/main/skills/MalavyaRaval/cleanup-reporter/SKILL.md) - Scan your machine for large directories, duplicate files, and stale resume files.
+- [cleanup-reporter](https://github.com/openclaw/skills/tree/main/skills/MalavyaRaval/cleanup-reporter/SKILL.md) - Scan for large directories, duplicate files, and stale resume files.
 > **[View all 180 skills in CLI Utilities →](categories/cli-utilities.md)**
 </details>
 

--- a/categories/cli-utilities.md
+++ b/categories/cli-utilities.md
@@ -2,7 +2,7 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**180 skills**
+**181 skills**
 
 - [13-day-sprint-method](https://github.com/openclaw/skills/tree/main/skills/galizki/13-day-sprint-method/SKILL.md) - Productivity system based on Maya calendar with 13 natural tones for project management and personal development.
 - [a-share-short-decision](https://github.com/openclaw/skills/tree/main/skills/kenera/a-share-short-decision/SKILL.md) - A-share short-term trading decision skill for 1-5 day horizon.
@@ -40,6 +40,7 @@
 - [claude-relay](https://github.com/openclaw/skills/tree/main/skills/artwalker/claude-relay/SKILL.md) - Relay operator for Claude Code via tmux across multiple projects.
 - [clawprint-verify](https://github.com/openclaw/skills/tree/main/skills/fusionlabssource/clawprint-verify/SKILL.md) - Issue ClawPrint reverse-CAPTCHA challenges.
 - [clean-pytest](https://github.com/openclaw/skills/tree/main/skills/marcoracer/clean-pytest/SKILL.md) - Write clean, maintainable pytest tests using Fake-based testing, contract testing, and dependency injection patterns.
+- [cleanup-reporter](https://github.com/openclaw/skills/tree/main/skills/MalavyaRaval/cleanup-reporter/SKILL.md) - Scan for large directories, duplicate files, and stale resume files.
 - [cli](https://github.com/openclaw/skills/tree/main/skills/mondilo1) - CLI reference for inspecting and checking skill eligibility.
 - [client-discovery](https://github.com/openclaw/skills/tree/main/skills/staybased/client-discovery/SKILL.md) - Run discovery conversations that qualify prospects, diagnose real problems, and position your solution.
 - [client-manager](https://github.com/openclaw/skills/tree/main/skills/mkpareek0315/client-manager/SKILL.md) - Track clients, projects, invoices, payments, earnings, leads, and time for freelancers.
@@ -184,4 +185,3 @@
 - [wind-site](https://github.com/openclaw/skills/tree/main/skills/qrost/wind-site/SKILL.md) - Wind rose, wind speed/direction at a site; supports site and urban wind assessment (data only; detailed CFD.
 - [wol-sleep-pc](https://github.com/openclaw/skills/tree/main/skills/oblivisheee/wol-sleep-pc/SKILL.md) - Send Wake-on-LAN (magic packet) and Sleep-on-LAN (inverted MAC) packets for a specific PC.
 - [xiaohongshu-automation](https://github.com/openclaw/skills/tree/main/skills/dingkwang/xiaohongshu-automation/SKILL.md) - A complete automation suite for Xiaohongshu (Little Red Book)
-- [cleanup-reporter](https://github.com/openclaw/skills/tree/main/skills/MalavyaRaval/cleanup-reporter/SKILL.md) - Scan your machine for large directories, duplicate files, and stale resume files.

--- a/edit_readme.py
+++ b/edit_readme.py
@@ -1,0 +1,32 @@
+import sys
+
+with open('/home/malav/.openclaw/workspace/tmp_awesome/README.md', 'r') as f:
+    content = f.read()
+
+# Locate the CLI Utilities section and insert the new line
+insertion = "\n- [cleanup-reporter](https://github.com/MalavyaRaval/cleanup-reporter) - Scan your machine for large directories, duplicate files, and stale resume files.\n"
+pattern = '<summary><h3 style="display:inline">CLI Utilities</h3></summary>'
+start_index = content.find(pattern)
+if start_index != -1:
+    # Look for the end of the details block or the end of the list inside the details
+    end_index = content.find('>', start_index)
+    # Just insert it at the end of the list inside that summary block
+    # It's better to insert it after the summary line? No, inside the list.
+    # I'll just append it to the end of the CLI Utilities section list.
+    list_end = content.find('>', start_index) # Just after the summary tag.
+    # Actually, the file uses a list: 
+    # - [13-day-sprint-method](...) - ...
+    # ...
+    # > **[View all 180 skills in CLI Utilities →](categories/cli-utilities.md)**
+    # I can just insert it before the "> **[View all..."
+    
+    insert_point = content.find('> **[View all', start_index)
+    if insert_point != -1:
+        new_content = content[:insert_point] + "- [cleanup-reporter](https://github.com/MalavyaRaval/cleanup-reporter) - Scan your machine for large directories, duplicate files, and stale resume files.\n" + content[insert_point:]
+        with open('/home/malav/.openclaw/workspace/tmp_awesome/README.md', 'w') as f:
+            f.write(new_content)
+        print("Updated README.md")
+    else:
+        print("Could not find insert point")
+else:
+    print("Could not find CLI Utilities section")

--- a/sort_cli.py
+++ b/sort_cli.py
@@ -1,0 +1,52 @@
+
+file_path = '/home/malav/.openclaw/workspace/tmp_awesome/categories/cli-utilities.md'
+
+with open(file_path, 'r') as f:
+    lines = f.readlines()
+
+new_lines = []
+skill_entries = []
+
+# Parse lines
+for line in lines:
+    if line.startswith('- ['):
+        skill_entries.append(line.strip())
+    else:
+        new_lines.append(line)
+
+# Filter unique entries for cleanup-reporter
+unique_entries = []
+seen = set()
+for entry in skill_entries:
+    if "cleanup-reporter" in entry:
+        if "cleanup-reporter" not in seen:
+            unique_entries.append(entry)
+            seen.add("cleanup-reporter")
+    else:
+        unique_entries.append(entry)
+
+# Sort alphabetically
+unique_entries.sort()
+
+# Reconstruct
+# The file has a header and intro text.
+# Find index to insert
+header_index = 0
+for i, line in enumerate(new_lines):
+    if line.startswith('- '):
+        header_index = i
+        break
+
+final_lines = new_lines[:header_index] + [entry + '\n' for entry in unique_entries] + new_lines[header_index:]
+
+# Update skill count header
+for i, line in enumerate(final_lines):
+    if "**180 skills**" in line:
+        final_lines[i] = line.replace("**180 skills**", "**181 skills**")
+    if "**181 skills**" in line:
+        pass # Already updated
+        
+with open(file_path, 'w') as f:
+    f.writelines(final_lines)
+
+print("Updated CLI Utilities list")


### PR DESCRIPTION
Adding my cleanup-reporter skill for community use.

ClawHub: https://clawhub.ai/cleanup-reporter
GitHub: https://github.com/MalavyaRaval/cleanup-reporter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "cleanup-reporter" entry to the CLI Utilities listing and updated the skills count to 181.
  * Added "cleanup-reporter" references to the flagged-list guidance and the License/Skills area.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->