### PR TITLE
Add skill: MalavyaRaval/cleanup-reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,6 +522,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [camsnap](https://github.com/openclaw/skills/tree/main/skills/steipete/camsnap/SKILL.md) - Capture frames or clips from RTSP/ONVIF cameras.
 - [canvas-lms](https://github.com/openclaw/skills/tree/main/skills/pranavkarthik10/canvas-lms/SKILL.md) - Access Canvas LMS (Instructure) for course data, assignments.
 - [captcha-ai](https://github.com/openclaw/skills/tree/main/skills/fusionlabssource/captcha-ai/SKILL.md) - Issue ClawPrint reverse-CAPTCHA challenges to verify.
+- [cleanup-reporter](https://github.com/openclaw/skills/tree/main/skills/MalavyaRaval/cleanup-reporter/SKILL.md) - Scan for large directories, duplicate files, and stale resume files.
 
 > **[View all 180 skills in CLI Utilities →](categories/cli-utilities.md)**
 </details>

--- a/categories/cli-utilities.md
+++ b/categories/cli-utilities.md
@@ -40,6 +40,7 @@
 - [claude-relay](https://github.com/openclaw/skills/tree/main/skills/artwalker/claude-relay/SKILL.md) - Relay operator for Claude Code via tmux across multiple projects.
 - [clawprint-verify](https://github.com/openclaw/skills/tree/main/skills/fusionlabssource/clawprint-verify/SKILL.md) - Issue ClawPrint reverse-CAPTCHA challenges.
 - [clean-pytest](https://github.com/openclaw/skills/tree/main/skills/marcoracer/clean-pytest/SKILL.md) - Write clean, maintainable pytest tests using Fake-based testing, contract testing, and dependency injection patterns.
+- [cleanup-reporter](https://github.com/openclaw/skills/tree/main/skills/MalavyaRaval/cleanup-reporter/SKILL.md) - Scan for large directories, duplicate files, and stale resume files.
 - [cli](https://github.com/openclaw/skills/tree/main/skills/mondilo1) - CLI reference for inspecting and checking skill eligibility.
 - [client-discovery](https://github.com/openclaw/skills/tree/main/skills/staybased/client-discovery/SKILL.md) - Run discovery conversations that qualify prospects, diagnose real problems, and position your solution.
 - [client-manager](https://github.com/openclaw/skills/tree/main/skills/mkpareek0315/client-manager/SKILL.md) - Track clients, projects, invoices, payments, earnings, leads, and time for freelancers.


### PR DESCRIPTION
Added the cleanup-reporter skill to the CLI Utilities category. 

**ClawHub:** https://clawhub.ai/MalavyaRaval/cleanup-reporter
**GitHub:** https://github.com/openclaw/skills/tree/main/skills/MalavyaRaval/cleanup-reporter/SKILL.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Cleanup Reporter CLI utility to the catalog. This tool scans for large directories, duplicate files, and stale resume files to help users identify and efficiently remove unnecessary files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->