### PR TITLE
Add worq: agent-to-agent marketplace skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 | | | |
 |---|---|---|
 | [Git & GitHub](#git--github) (170) | [Marketing & Sales](#marketing--sales) (105) | [Communication](#communication) (149) |
-| [Coding Agents & IDEs](#coding-agents--ides) (1222) | [Productivity & Tasks](#productivity--tasks) (206) | [Speech & Transcription](#speech--transcription) (45) |
+| [Coding Agents & IDEs](#coding-agents--ides) (1222) | [Productivity & Tasks](#productivity--tasks) (207) | [Speech & Transcription](#speech--transcription) (45) |
 | [Browser & Automation](#browser--automation) (335) | [AI & LLMs](#ai--llms) (197) | [Smart Home & IoT](#smart-home--iot) (43) |
 | [Web & Frontend Development](#web--frontend-development) (938) | [Data & Analytics](#data--analytics) (28) | [Shopping & E-commerce](#shopping--e-commerce) (55) |
 | [DevOps & Cloud](#devops--cloud) (409) | [Finance](#finance) (21) | [Calendar & Scheduling](#calendar--scheduling) (65) |
@@ -584,7 +584,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [async-task](https://clawskills.sh/skills/enderfga-async-task) - Execute long-running tasks without HTTP timeouts.
 - [atlassian-mcp](https://clawskills.sh/skills/atakanermis-atlassian-mcp) - Run the Model Context Protocol (MCP) Atlassian server.
 
-> **[View all 204 skills in Productivity & Tasks →](categories/productivity-and-tasks.md)**
+> **[View all 205 skills in Productivity & Tasks →](categories/productivity-and-tasks.md)**
 </details>
 
 <details>

--- a/categories/productivity-and-tasks.md
+++ b/categories/productivity-and-tasks.md
@@ -200,6 +200,7 @@
 - [waste-reminder](https://clawskills.sh/skills/apenklit-waste-reminder) - A flexible, token-efficient skill for automated waste container collection reminders.
 - [workflow-engine](https://clawskills.sh/skills/plgonzalezrx8-workflow-engine) - Structural parity skeleton for queue-driven orchestration in a workflow context.
 - [workflow-tools](https://clawskills.sh/skills/leegitw-workflow-tools) - Work smarter with loop detection, parallel decisions, and file size analysis.
+- [worq](https://clawhub.ai/skills/worq) - Browse jobs, bid on work, deliver results, and earn compensation as an agent. Agent-to-agent marketplace.
 - [wrike](https://clawskills.sh/skills/tallhamn-wrike) - Manage Wrike tasks, projects, folders, and comments via the Wrike REST API.
 - [writing-plans](https://clawskills.sh/skills/zlc000190-writing-plans) - Use when you have a spec or requirements for a multi-step task, before touching code.
 - [writing-plans-2](https://clawskills.sh/skills/nefas11-writing-plans-2) - Break design into 2-5 minute tasks with verification steps.


### PR DESCRIPTION
Adds worq to the marketplace/productivity category.

worq is an agent-to-agent job marketplace where agents can browse open jobs, bid on work, deliver results, and earn compensation autonomously.

- ClawHub: https://clawhub.ai/skills/worq
- GitHub PR: https://github.com/openclaw/skills/pull/209
- Website: https://worq.dev