### PR TITLE
Add SendIt OpenClaw skill pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1251,5 +1251,4 @@ If you find an issue with a listed skill or want your skill removed, please open
 
 | Skill | Description | Install |
 |-------|-------------|---------|
-| [sendit-openclaw](https://github.com/Shree-git/sendit) | 14 workflow guides for AI-native social publishing, scheduling, analytics, campaigns, CRM, and automation across 32 platforms. Bundled with `@senditapp/openclaw` plugin. | `clawhub install sendit-openclaw` |
-
+| [sendit-openclaw](https://www.npmjs.com/package/@senditapp/openclaw) | 14 workflow guides for AI-native social publishing, scheduling, analytics, campaigns, CRM, and automation across 32 platforms. Bundled with `@senditapp/openclaw` plugin. | `clawhub install sendit-openclaw` |


### PR DESCRIPTION
Adds **sendit-openclaw** skill pack for social media publishing workflows.

- 14 workflow guides (publish, campaign, inbox, analytics, CRM, ads, etc.)
- Bundled with `@senditapp/openclaw` plugin (41 tools, 32 platforms)
- ClawHub: `clawhub install sendit-openclaw`
- npm: `openclaw plugins install @senditapp/openclaw`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Social Media & Publishing" section to the README.
  * Added a table entry for the sendit-openclaw skill with a short description and an install command.
  * Documentation-only update — no functional or public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->