### PR TITLE
Add skill: blueyi/domain-checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 | [Apple Apps & Services](#apple-apps--services) (44) | [Notes & PKM](#notes--pkm) (70) | [Self-Hosted & Automation](#self-hosted--automation) (33) |
 | [Search & Research](#search--research) (345) | [iOS & macOS Development](#ios--macos-development) (29) | [Security & Passwords](#security--passwords) (53) |
 | [Clawdbot Tools](#clawdbot-tools) (37) | [Transportation](#transportation) (110) | [Moltbook](#moltbook) (29) |
-| [CLI Utilities](#cli-utilities) (179) | [Personal Development](#personal-development) (50) | [Gaming](#gaming) (35) |
+| [CLI Utilities](#cli-utilities) (180) | [Personal Development](#personal-development) (50) | [Gaming](#gaming) (35) |
 | [Health & Fitness](#health--fitness) (87) | | |
 
 
@@ -523,7 +523,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [canvas-lms](https://clawskills.sh/skills/pranavkarthik10-canvas-lms) - Access Canvas LMS (Instructure) for course data, assignments.
 - [captcha-ai](https://clawskills.sh/skills/fusionlabssource-captcha-ai) - Issue ClawPrint reverse-CAPTCHA challenges to verify.
 
-> **[View all 179 skills in CLI Utilities →](categories/cli-utilities.md)**
+> **[View all 180 skills in CLI Utilities →](categories/cli-utilities.md)**
 </details>
 
 <details>

--- a/categories/cli-utilities.md
+++ b/categories/cli-utilities.md
@@ -60,6 +60,7 @@
 - [dependency-audit](https://clawskills.sh/skills/fratua-dependency-audit) - Smart dependency health check — security audit, outdated detection, unused deps, and prioritized update plan.
 - [django-creator](https://clawskills.sh/skills/moenassi-django-creator) - This project eliminates the time wasted on creating virtual machines and setting up environments from scratch.
 - [django-tool](https://clawskills.sh/skills/moenassi-django-tool) - This project eliminates the time wasted on creating virtual machines and setting up environments from scratch.
+- [domain-checker](https://clawhub.ai/blueyi/domain-checker) - Check domain availability via whois + DNS cross-verification. Supports .com, .net, .org, .io, .ai, .so, and other TLDs.
 - [dsiprouter-skill](https://clawskills.sh/skills/mackhendricks-dsiprouter-skill) - Call the dSIPRouter REST API using the Postman.
 - [dwlf](https://clawskills.sh/skills/andywilliams-dwlf) - Interact with DWLF (dwlf.co.uk), a market analysis platform for crypto.
 - [ecto](https://clawskills.sh/skills/visionik-ecto) - Ghost.io blog management via Admin API.


### PR DESCRIPTION
Add domain-checker to CLI Utilities category.

- ClawHub: https://clawhub.ai/blueyi/domain-checker
- GitHub: https://github.com/openclaw/skills/tree/main/skills/blueyi/domain-checker

Check domain availability via whois + DNS cross-verification. Supports .com, .net, .org, .io, .ai, .so, and other TLDs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "domain-checker" to the CLI Utilities collection.

* **Documentation**
  * Updated CLI Utilities listing and link text in the README to reflect the new item count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->