### PR TITLE
Add skill: Arlieeee/meshy-3d-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,8 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [calorie-visualizer](https://clawskills.sh/skills/vintlin-calorie-visualizer) - Local calorie logging and visual reporting (auto-refreshes and returns report image after each log)
 - [canva-connect](https://clawskills.sh/skills/coolmanns-canva-connect) - Manage Canva designs, assets, and folders via the Connect API.
 
+- [meshy-3d-agent](https://clawskills.sh/skills/arlieeee-meshy-3d-agent) - Full 3D generation, rigging, animation, and printing via Meshy AI.
+
 > **[View all 169 skills in Image & Video Generation →](categories/image-and-video-generation.md)**
 </details>
 


### PR DESCRIPTION
Adds `meshy-3d-agent` to the **Image & Video Generation** section.

Full 3D generation pipeline via the [Meshy AI](https://www.meshy.ai) API: text/image-to-3D, retexture, rig, animate, and 3D print preparation with Bambu Studio integration.

**Links:**
- ClawHub: https://clawhub.ai/Arlieeee/meshy-3d-agent
- GitHub: https://github.com/meshy-dev/meshy-3d-agent

**Install:**
```bash
npx clawhub install Arlieeee/meshy-3d-agent
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated the Image & Video Generation section with a new skill entry for meshy-3d-agent, making it available for reference alongside other tools in this category.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->