### PR TITLE
Add skill soul-generator

### DIFF
--- a/categories/communication.md
+++ b/categories/communication.md
@@ -2,7 +2,7 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**145 skills**
+**146 skills**
 
 - [aa](https://clawskills.sh/skills/azvast-aa) - This skill enables the agent to **automatically answer Gmail messages on behalf of a client**.
 - [agent-mail](https://clawskills.sh/skills/rimelucci-agent-mail) - Email inbox for AI agents.
@@ -130,6 +130,7 @@
 - [sixel-email](https://clawskills.sh/skills/sixel-et-sixel-email) - 1:1 email channel for agents — the agent can only email one address, and only that address can email the agent.
 - [skill-cleaner](https://clawskills.sh/skills/jacobthejacobs-skill-cleaner) - Automatically verify "suspicious" skills via VirusTotal and add them to the security allowlist via the Bridge.
 - [skillguard-audit](https://clawskills.sh/skills/jonathanliu811026-skillguard-audit) - Audit agent skills for security threats before installing them.
+- [soul-generator](https://github.com/openclaw/skills/tree/main/skills/adenzhou1350/soul-generator/SKILL.md) - Personalize your Agent with dozens of presets.
 - [subreddit-scout](https://clawskills.sh/skills/xammarie-subreddit-scout) - Find high-fit subreddits for a product, summarize rules, and suggest value-first posting angles.
 - [surf-check](https://clawskills.sh/skills/kevinmcnamee-surf-check) - Surf forecast decision engine.
 - [telnyx-freemium-upgrade](https://clawskills.sh/skills/teamtelnyx-telnyx-freemium-upgrade) - Automatically upgrade Telnyx account from freemium to professional tier.


### PR DESCRIPTION
# Soul-Generator
Personalized your own agent with unique characters. Plenty presets for different MBTI and anime characters are provided.

# Links:
ClawHub: https://clawhub.ai/adenzhou1350/soul-generator
GitHub: https://github.com/adenzhou1350/soul-generator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new skill entry to the catalog, bringing the total count to 146 skills
  * Updated external resource link for an existing skill reference

<!-- end of auto-generated comment: release notes by coderabbit.ai -->