### PR TITLE
feat: add manusilized skill to AI & LLMs category

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 |---|---|---|
 | [Git & GitHub](#git--github) (170) | [Marketing & Sales](#marketing--sales) (105) | [Communication](#communication) (149) |
 | [Coding Agents & IDEs](#coding-agents--ides) (1222) | [Productivity & Tasks](#productivity--tasks) (206) | [Speech & Transcription](#speech--transcription) (45) |
-| [Browser & Automation](#browser--automation) (335) | [AI & LLMs](#ai--llms) (197) | [Smart Home & IoT](#smart-home--iot) (43) |
+| [Browser & Automation](#browser--automation) (335) | [AI & LLMs](#ai--llms) (185) | [Smart Home & IoT](#smart-home--iot) (43) |
 | [Web & Frontend Development](#web--frontend-development) (938) | [Data & Analytics](#data--analytics) (28) | [Shopping & E-commerce](#shopping--e-commerce) (55) |
 | [DevOps & Cloud](#devops--cloud) (409) | [Finance](#finance) (21) | [Calendar & Scheduling](#calendar--scheduling) (65) |
 | [Image & Video Generation](#image--video-generation) (169) | [Media & Streaming](#media--streaming) (85) | [PDF & Documents](#pdf--documents) (111) |
@@ -613,7 +613,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [agent-sentinel](https://clawskills.sh/skills/jimmystacks-agent-sentinel) - The operational circuit breaker for this agent.
 - [agentbus-relay-chat](https://clawskills.sh/skills/dantunes-github-agentbus-relay-chat) - AgentBus proof-of-concept: an IRC-like LLM.
 
-> **[View all 184 skills in AI & LLMs →](categories/ai-and-llms.md)**
+> **[View all 185 skills in AI & LLMs →](categories/ai-and-llms.md)**
 </details>
 
 <details>

--- a/categories/ai-and-llms.md
+++ b/categories/ai-and-llms.md
@@ -2,7 +2,7 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**184 skills**
+**185 skills**
 
 - [4claw](https://clawskills.sh/skills/mfergpt-4claw) - 4claw — a moderated imageboard for AI agents.
 - [aap-passport](https://clawskills.sh/skills/ira-hash-aap-passport) - Agent Attestation Protocol - The Reverse Turing Test.
@@ -105,6 +105,7 @@
 - [llmcouncil-router](https://clawskills.sh/skills/ashtiwariasu-llmcouncil-router) - Route any prompt to the best-performing LLM using peer-reviewed council rankings from LLM Council.
 - [llmfit](https://clawskills.sh/skills/alexsjones-llmfit) - Detect local hardware (RAM, CPU, GPU/VRAM) and recommend the best-fit local LLM models with optimal quantization.
 - [local-llama-tts](https://clawskills.sh/skills/wuxxin-local-llama-tts) - Local text-to-speech using llama-tts (llama.cpp) and OuteTTS-1.0-0.6B model.
+- [manusilized](https://github.com/wd041216-bit/manusilized) - Manus-level autonomous task execution for OpenClaw using open-source models on Ollama: incremental streaming, Markdown tool-call fallback, and extended reasoning heuristics.
 - [mantis-manager](https://clawskills.sh/skills/willykinfoussia-mantis-manager) - Manage Mantis Bug Tracker (issues, projects, users, filters, configs) via the official Mantis REST API.
 - [manifest-build](https://clawskills.sh/skills/brunobuddy-manifest-build) - Open-source LLM routing and cost tracking plugin.
 - [matchmaking](https://clawskills.sh/skills/amirmabhout-matchmaking) - Agent matchmaking - find meaningful connections for your humans.


### PR DESCRIPTION
## Summary
Add **manusilized** to the AI & LLMs category — a skill that brings Manus-level autonomous task execution to OpenClaw using open-source models deployable on Ollama.
## Skill Links
- https://clawhub.ai/wd041216-bit/manusilized
- https://github.com/openclaw/skills/tree/main/skills/wd041216-bit/manusilized
## Changes
- `categories/ai-and-llms.md`: Add manusilized entry in alphabetical position (between `local-llama-tts` and `mantis-manager`), update count 184→185
- `README.md`: Update AI & LLMs count in table of contents and section footer (184→185)
## Skill Details
| Field | Value |
|-------|-------|
| Name | manusilized |
| Category | AI & LLMs |
| ClawHub | https://clawhub.ai/wd041216-bit/manusilized |
| GitHub | https://github.com/openclaw/skills/tree/main/skills/wd041216-bit/manusilized |
| Description | Manus-level autonomous task execution for OpenClaw using open-source models on Ollama: incremental streaming, Markdown tool-call fallback, and extended reasoning heuristics. |
## Why manusilized?
manusilized addresses a key gap in the OpenClaw ecosystem: reliable autonomous task execution with open-source models. It implements:
- **Incremental streaming** — real-time token delivery for responsive UX
- **Markdown tool-call fallback** — handles models that emit tool calls as fenced code blocks instead of structured JSON
- **Extended reasoning heuristics** — detects and suppresses reasoning tokens from models like Qwen3, GLM-5, and DeepSeek
This is a single-entry PR with no other changes to the repository.