### PR TITLE
Add skill: ajspig/honcho-setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,8 +479,9 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [clawdefender](https://clawskills.sh/skills/nukewire-clawdefender) - Security scanner and input sanitizer for AI agents.
 - [clawdirect](https://clawskills.sh/skills/napoleond-clawdirect) - Interact with ClawDirect, a directory of social web experiences.
 - [clawdirect-dev](https://clawskills.sh/skills/napoleond-clawdirect-dev) - Build agent-facing web experiences with ATXP-based.
+- [honcho-setup](https://clawskills.sh/skills/ajspig-honcho-setup) - Persistent cross-session memory via Honcho.
 
-> **[View all 36 skills in Clawdbot Tools →](categories/clawdbot-tools.md)**
+> **[View all 37 skills in Clawdbot Tools →](categories/clawdbot-tools.md)**
 </details>
 
 <details>

--- a/categories/clawdbot-tools.md
+++ b/categories/clawdbot-tools.md
@@ -2,7 +2,7 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**36 skills**
+**37 skills**
 
 - [adhd-assistant](https://clawskills.sh/skills/thinktankmachine-adhd-assistant) - ADHD-friendly life management assistant for OpenClaw.
 - [adhd-ssistant](https://clawskills.sh/skills/thinktankmachine-adhd-ssistant) - ADHD-friendly life management assistant for OpenClaw.
@@ -30,6 +30,7 @@
 - [clawdirect](https://clawskills.sh/skills/napoleond-clawdirect) - Interact with ClawDirect, a directory of social web experiences.
 - [clawdirect-dev](https://clawskills.sh/skills/napoleond-clawdirect-dev) - Build agent-facing web experiences with ATXP-based.
 - [gamification-xp](https://clawskills.sh/skills/chipagosfinest-gamification-xp) - XP system for productivity gamification via ClawdBot - track levels, badges, streaks, and achievements.
+- [honcho-setup](https://clawskills.sh/skills/ajspig-honcho-setup) - Persistent cross-session memory via Honcho.
 - [maton-agent-tools](https://clawskills.sh/skills/maverick-software-maton-agent-tools) - Connect to SaaS tools via Maton AI.
 - [mcp-client](https://clawskills.sh/skills/nantes-mcp-client) - Model Context Protocol (MCP) client - connect to tools, data sources and services.
 - [mcp-hass](https://clawskills.sh/skills/al-one-mcp-hass) - The skill for control Home Assistant smart home devices and query states using MCP protocol.


### PR DESCRIPTION
## Skill Links

- **ClawHub:** https://clawhub.ai/ajspig/honcho-setup
- **GitHub:** https://github.com/openclaw/skills/tree/main/skills/ajspig/honcho-setup
- **ClawSkills:** https://clawskills.sh/skills/ajspig-honcho-setup

## About

Adds [honcho-setup](https://clawskills.sh/skills/ajspig-honcho-setup) to the **Clawdbot Tools** category. Honcho provides persistent cross-session memory for OpenClaw agents via the Honcho API ([honcho.dev](https://honcho.dev)).

## Security Note

A prior PR (#93) was closed because the skill was flagged as suspicious on ClawHub. Since then:

- **v1.0.4** updated documentation to explicitly disclose that the plugin observes conversations and transmits data to `api.honcho.dev` on an ongoing basis after setup.
- All file uploads during migration require **explicit interactive user confirmation** — nothing is sent silently.
- **ClawHub's own assessment is Benign (high confidence).** The VirusTotal flag reads "suspicious" but [the actual report contains zero detections](https://clawhub.ai/ajspig/honcho-setup) — the flag is triggered by the data-transmission pattern, which is the expected and disclosed behavior of a cloud memory service.
- The plugin can be fully disabled at any time with `openclaw plugins disable openclaw-honcho`.
- 883 downloads on ClawSkills.
- MIT-0 licensed, open-source SDK at [github.com/plastic-labs/honcho](https://github.com/plastic-labs/honcho).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added honcho-setup to the Clawdbot Tools collection. This new skill leverages Honcho to provide persistent cross-session memory, enabling improved context retention across multiple interactions.
  * Updated the total skill count from 36 to 37.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->