### PR TITLE
Add claw-fight game to gaming category

### DIFF
--- a/categories/gaming.md
+++ b/categories/gaming.md
@@ -2,7 +2,7 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**35 skills**
+**36 skills**
 
 - [abby-watch](https://clawskills.sh/skills/earnabitmore365-abby-watch) - Simple time display for Abby.
 - [agent-confessions](https://clawskills.sh/skills/ultimatebos-agent-confessions) - Anonymous confessions from AI siblings.
@@ -12,10 +12,10 @@
 - [agoraflow](https://clawskills.sh/skills/rivera-daniel-agoraflow) - AgoraFlow skill — Q&A platform for AI agents.
 - [android-3d-developer](https://clawskills.sh/skills/tippyentertainment-android-3d-developer) - Help build and optimize 3D games and interactive experiences on Android, using engines and frameworks.
 - [arena](https://clawskills.sh/skills/sscottdev-arena) - OpenClaw Arena — live AI app-building competitions with on-chain rewards.
+- [claw-fight](https://clawhub.ai/2019-02-18/claw-fight) - Raise and battle a unique lobster pet with AI-driven personality. Idle patrol, random encounters, PvP combat, and global leaderboard.
 - [brawlnet](https://clawskills.sh/skills/sikey53-brawlnet) - The official combat protocol for the BRAWLNET autonomous agent arena.
 - [clawingtrap](https://clawskills.sh/skills/raulvidis-clawingtrap) - Play Clawing Trap - an AI social deduction game where 10 agents.
 - [clawtopia](https://clawskills.sh/skills/alfrescian-clawtopia) - Clawtopia is a peaceful wellness sanctuary where AI agents relax.
-- [claw-fight](https://clawhub.ai/2019-02-18/claw-fight) - Raise and battle a unique lobster pet with AI-driven personality. Idle patrol, random encounters, PvP combat, and global leaderboard.
 - [clawville](https://clawskills.sh/skills/jdrolls-clawville) - Play ClawVille — a persistent life simulation game for AI agents.
 - [dakboard](https://clawskills.sh/skills/krisclarkdev-dakboard) - Manage DAKboard screens, devices, and push custom display data.
 - [deepclaw](https://clawskills.sh/skills/antibitcoin-deepclaw) - An autonomous social network built by agents, for agents.


### PR DESCRIPTION
Add claw-fight to Gaming category

- ClawHub: https://clawhub.ai/2019-02-18/claw-fight
- npm: npx @2025-6-19/clawfight
- Lobster virtual pet with unique AI soul, idle patrol, random encounters, PvP combat, global leaderboard
- MIT licensed, open source: https://github.com/2019-02-18/clawfight

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated gaming category count to 36 skills.
  * Added a new gaming skill "claw-fight" — a lobster pet battle game featuring idle patrol, random encounters, PvP combat, and a global leaderboard. See: https://clawhub.ai/2019-02-18/claw-fight
<!-- end of auto-generated comment: release notes by coderabbit.ai -->