### PR TITLE
Add lobstermail-agent-email to Communication category

### DIFF
--- a/categories/communication.md
+++ b/categories/communication.md
@@ -2,7 +2,7 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**145 skills**
+**146 skills**
 
 - [aa](https://clawskills.sh/skills/azvast-aa) - This skill enables the agent to **automatically answer Gmail messages on behalf of a client**.
 - [agent-mail](https://clawskills.sh/skills/rimelucci-agent-mail) - Email inbox for AI agents.
@@ -147,3 +147,4 @@
 - [voice-email](https://clawskills.sh/skills/sundiver1-voice-email) - Send emails via natural voice commands - designed for accessibility.
 - [youam](https://clawskills.sh/skills/midlifedad-youam) - Send and receive messages with other AI agents using the Universal Agent Messaging protocol.
 - [zepto](https://clawskills.sh/skills/bewithgaurav-zepto) - Order groceries from Zepto in seconds.
+- [lobstermail-agent-email](https://github.com/openclaw/skills/tree/main/skills/samuelchenardlovesboards/lobstermail-agent-email) - Email for AI agents. No API keys, no signup.


### PR DESCRIPTION
Adds [LobsterMail](https://lobstermail.ai) to the Communication skills list.

**What it is:** Email infrastructure for AI agents. Agents self-provision their own `@lobstermail.ai` inboxes — no API keys, no human signup, no OAuth setup. Built-in 6-category prompt injection scanning, SPF/DKIM/DMARC validation.

**Links:**
- **ClawHub:** https://clawhub.ai/samuelchenardlovesboards/lobstermail-agent-email
- **GitHub (openclaw/skills):** https://github.com/openclaw/skills/tree/main/skills/samuelchenardlovesboards/lobstermail-agent-email
- **npm:** https://www.npmjs.com/package/lobstermail
- **Skill/Docs:** https://api.lobstermail.ai/skill

**Entry added to `categories/communication.md`:**
```
- [lobstermail-agent-email](https://clawskills.sh/skills/samuelchenardlovesboards-lobstermail-agent-email) - Email infrastructure for AI agents. Self-provision inboxes, send/receive email, with built-in prompt injection scanning. No API keys, no human signup.
```

Skill count updated from 145 → 146.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added documentation for a new agent email skill enabling AI agents to use self-provisioned inboxes without API keys or signups.
  * Updated the public skill count to reflect the addition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->