### PR TITLE
Add tunelo to DevOps & Cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [agentkeys](https://clawskills.sh/skills/alexandr-belogubov-agentkeys) - Secure credential proxy for AI agents.
 - [agentmemory](https://clawskills.sh/skills/badaramoni-agentmemory) - End-to-end encrypted cloud memory for AI agents.
 
+- [tunelo](https://clawhub.ai/skills/tunelo) - Expose local ports and files to the internet via QUIC tunnel. Built-in web file explorer, auto-reconnect, private tunnels.
 > **[View all 392 skills in DevOps & Cloud →](categories/devops-and-cloud.md)**
 </details>
 


### PR DESCRIPTION
**[tunelo](https://clawhub.ai/skills/tunelo)** — Expose local ports and files to the internet via QUIC tunnel.

Published on ClawHub: `clawhub install tunelo`

- `tunelo http 3000` → public HTTPS URL for dev server
- `tunelo serve .` → file browser with code/PDF/video preview
- QUIC transport, auto-reconnect, private tunnels
- GitHub: https://github.com/jiweiyuan/tunelo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the tunelo skill, describing how to expose local ports and files to the internet via QUIC tunnels with features including web file explorer, auto-reconnect, and private tunnels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->