### PR TITLE
Add mineswap-agent — DEX aggregator on Base with BG cashback

### DIFF
--- a/categories/shopping-and-e-commerce.md
+++ b/categories/shopping-and-e-commerce.md
@@ -2,7 +2,7 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**51 skills**
+**52 skills**
 
 - [add-wish](https://clawskills.sh/skills/leebellon-add-wish) - Save any product to a universal wishlist.
 - [agentic-commerce](https://clawskills.sh/skills/purch-agent-agentic-commerce) - AI-powered shopping API for product search and crypto.
@@ -39,6 +39,7 @@
 - [jtbd-analyzer](https://clawskills.sh/skills/artyomx33-jtbd-analyzer) - Uncover the real "job" customers hire your product.
 - [listonic](https://clawskills.sh/skills/jeremymahieu-listonic) - Access Listonic shopping lists: list lists/items, add/check/delete items, and manage lists.
 - [marktplaats](https://clawskills.sh/skills/pvoo-marktplaats) - Search Marktplaats.nl classifieds across all categories with filtering.
+- [mineswap-agent](https://clawskills.sh/skills/skylerthegoldgod-mineswap-agent) - Swap tokens on Base via MineSwap DEX aggregator. 8-DEX routing, 0.3% fee with 0.075% cashback as BG.
 - [moltlist-marketplace](https://clawskills.sh/skills/koriyoshi2041-moltlist-marketplace) - Interact with the moltlist.com agent.
 - [moltpho](https://clawskills.sh/skills/unifiedh-moltpho) - Shop autonomously on Amazon via Moltpho - search products, manage credit.
 - [moonpay](https://clawskills.sh/skills/kevarifin14-moonpay) - Your agent needs money.
@@ -53,4 +54,3 @@
 - [tradekix](https://clawskills.sh/skills/jamesjohnfox-tradekix) - Query financial market data via the Tradekix API — stock prices, crypto, forex, indices, market news, earnings.
 - [turnip-prophet](https://clawskills.sh/skills/nicholasjackson-turnip-prophet) - Predict Animal Crossing New Horizons turnip prices using the game's exact algorithm.
 - [whop-cli](https://clawskills.sh/skills/g9pedro-whop-cli) - Manage Whop digital products store — create products, plans, track payments, manage memberships.
-- [mineswap-agent](https://clawskills.sh/skills/skylerthegoldgod-mineswap-agent) - Swap any token on Base via MineSwap DEX aggregator. 8-DEX routing, BG cashback on every trade, autonomous buyback-and-burn. Industry-standard 0.3% fee but you get 0.075% back as BG.


### PR DESCRIPTION
Adds mineswap-agent skill. MineSwap routes across 8 DEXs on Base for best price. 0.3% fee split: 0.15% LP + 0.075% burn + 0.075% BG cashback to swapper. Agents earn deflationary BG on every trade.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new token swapping skill for the Base network via the MineSwap DEX aggregator, offering multi-DEX routing and integrated fee/cashback mechanics.
* **Chores**
  * Updated the Shopping & E-commerce category skill count to 52.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->