### PR TITLE
Add skill: DevOps Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [agentkeys](https://clawskills.sh/skills/alexandr-belogubov-agentkeys) - Secure credential proxy for AI agents.
 - [agentmemory](https://clawskills.sh/skills/badaramoni-agentmemory) - End-to-end encrypted cloud memory for AI agents.
 
+- [devops-agent](https://clawhub.ai/s/devops-agent) - One-click deploy, monitoring setup (Prometheus+Grafana), scheduled backups, and fault diagnosis with safety-first design including confirmation prompts, dry-run, and snapshot rollback
 > **[View all 392 skills in DevOps & Cloud →](categories/devops-and-cloud.md)**
 </details>
 


### PR DESCRIPTION
## New Skill: DevOps Agent

**DevOps Agent** — One-click deploy, monitoring setup (Prometheus+Grafana), scheduled backups, and fault diagnosis with safety-first design including confirmation prompts, dry-run, and snapshot rollback

- **GitHub**: https://github.com/fullstackcrew-alpha/skill-devops-agent
- **ClawHub**: https://clawhub.ai/s/devops-agent
- **Install**: `clawhub install devops-agent`
- **License**: MIT

Published by [FullStackCrew](https://github.com/fullstackcrew-alpha).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added information about the devops-agent skill in the DevOps & Cloud section, detailing one-click deployment, Prometheus and Grafana monitoring setup, automated scheduled backups, fault diagnosis capabilities, and safety-first features including confirmation prompts, dry-run support, and snapshot rollback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->