### PR TITLE
Add skill: CN Content Matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,6 +556,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [brand-voice-profile](https://clawskills.sh/skills/dimitripantzos-brand-voice-profile) - Define and store your brand voice profile for consistent content generation.
 - [brevo](https://clawskills.sh/skills/yujesyoga-brevo) - Brevo (formerly Sendinblue) email marketing API for managing contacts, lists,.
 
+- [cn-content-matrix](https://clawhub.ai/s/cn-content-matrix) - Chinese multi-platform content generator for Xiaohongshu, WeChat, Douyin, and Bilibili with true style transfer, compliance review, and sensitive word detection
 > **[View all 103 skills in Marketing & Sales →](categories/marketing-and-sales.md)**
 </details>
 


### PR DESCRIPTION
## New Skill: CN Content Matrix

**CN Content Matrix** — Chinese multi-platform content generator for Xiaohongshu, WeChat, Douyin, and Bilibili with true style transfer, compliance review, and sensitive word detection

- **GitHub**: https://github.com/fullstackcrew-alpha/skill-cn-content-matrix
- **ClawHub**: https://clawhub.ai/s/cn-content-matrix
- **Install**: `clawhub install cn-content-matrix`
- **License**: MIT

Published by [FullStackCrew](https://github.com/fullstackcrew-alpha).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

- Added cn-content-matrix to the Marketing & Sales tools list—a new Chinese multi-platform content generator designed for Xiaohongshu, WeChat, Douyin, and Bilibili. The tool provides style transfer capabilities for content adaptation, automated compliance review to meet regulatory standards, and sensitive word detection for content safety and quality assurance across these platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->