### PR TITLE
Add skill: msaleme/agent-security-harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1093,7 +1093,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [1claw](https://clawskills.sh/skills/kmjones1979-1claw) - HSM-backed vault for agent secrets; store, rotate, share securely.
 - [age-verification](https://clawskills.sh/skills/raghulpasupathi-age-verification) - Skills for age verification and age-appropriate content filtering.
 - [amai-id](https://www.clawhub.ai/Gonzih/amai-id) - Soul-Bound Keys and Soulchain for persistent.
-- [agent-security-harness](https://clawhub.ai/skills/agent-security-harness) - 209 security tests for AI agent systems. MCP, A2A, L402, x402 wire-protocol testing, 20 enterprise platforms, GTG-1002 APT simulation. Agent Autonomy Risk Score for payment endpoints. pip install agent-security-harness.
+- [agent-security-harness](https://github.com/openclaw/skills/tree/main/skills/msaleme/agent-security-harness/SKILL.md) - Security testing for AI agent wire protocols and platforms.
 - [api-security](https://clawskills.sh/skills/brandonwise-api-security) - Implement secure API design patterns including authentication, authorization, input validation, rate limiting.
 - [audit-badge-demo](https://clawskills.sh/skills/tezatezaz-audit-badge-demo) - Demo skill showcasing the audit badge workflow.
 - [auditing-appstore-readiness](https://clawskills.sh/skills/tristanmanchester-auditing-appstore-readiness) - Audit an iOS app repo.


### PR DESCRIPTION
Adding agent-security-harness to the Security & Passwords category.

Security testing for AI agent wire protocols and platforms. 209 tests across MCP, A2A, L402, x402.

- ClawHub: https://clawhub.ai/msaleme/agent-security-harness
- GitHub: https://github.com/openclaw/skills/tree/main/skills/msaleme/agent-security-harness

Note: Skill was just published to ClawHub and is syncing to the official skills repo. The sync is active (other skills syncing within ~30 min).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new security resource entry for "agent-security-harness" with its link and a description of its use for security testing of AI agent wire protocols and platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->