### PR TITLE
Add cc-soul — cognitive architecture plugin (memory, personality, emotion)

### DIFF
--- a/README.md
+++ b/README.md
@@ -801,6 +801,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [beaverhabits](https://clawskills.sh/skills/daya0576-beaverhabits) - Track and manage your habits using the Beaver Habit Tracker API.
 - [brw-case-study-builder](https://clawskills.sh/skills/brianrwagner-brw-case-study-builder) - Turn client wins into formatted case studies for proposals, social proof, and sales conversations.
 - [canvas-design](https://clawskills.sh/skills/seanphan-canvas-design) - Create beautiful visual art in .png and .pdf documents.
+- [cc-soul](https://clawskills.sh/skills/wenroudeyu-collab-cc-soul) - Give your AI a soul — persistent memory (10K+ entries with semantic search), adaptive personality (10 auto-switching personas), emotional awareness (7-day mood arcs), dream-mode cross-domain association, and self-evolution. 50 modules, 20K+ lines TypeScript, 123 features.
 - [cedh-advisor](https://clawskills.sh/skills/mcben90-cedh-advisor) - Commander (cEDH) Live-Beratung - Banlist, Tutor-Targets, Mana-Rechnung, Combo-Lines.
 - [clawcierge](https://clawskills.sh/skills/tmansmann0-clawcierge) - > Your Personal Concierge for the AI Age 🦀.
 - [crucial-conversations-coach](https://clawskills.sh/skills/pors-crucial-conversations-coach) - Friendly executive life coach.


### PR DESCRIPTION
## What is cc-soul?

A cognitive architecture plugin that gives your OpenClaw AI a persistent soul:

- **10,000+ persistent memories** with semantic search — your AI never forgets
- **10 adaptive personas** (engineer, friend, mentor, strategist...) that auto-switch by context
- **Emotion detection** with 7-day mood arcs — emotionally aware responses
- **Dream mode** — idle-time cross-domain association and creative linking
- **Correction attribution** — analyzes why mistakes happened, prevents repeats
- **Proactive thinking** — every reply auto-expands with lateral insights

**50 modules | 20K+ lines TypeScript | 123 features**

## Links

- ClawHub: https://clawhub.ai/wenroudeyu-collab/cc-soul
- GitHub: https://github.com/wenroudeyu-collab/cc-soul
- npm: https://www.npmjs.com/package/@cc-soul/openclaw

## Install

```bash
openclaw plugins install @cc-soul/openclaw
```

## Where in the list?

Added to **Personal Development** category (alphabetical order), as cc-soul focuses on agent self-awareness, memory, personality growth, and emotional intelligence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new skill entry (`cc-soul`) to the README under "Personal Development" section, including details about its capabilities such as persistent semantic memory, adaptive personality, emotional arcs, cross-domain associations, and self-evolution features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->