### PR TITLE
docs: refresh Cross-Validated Search OpenClaw listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,7 +453,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [ai-review](https://clawskills.sh/skills/blackshady1130-jpg-ai-review) - Reads content from URLs or files, classifies it, and generates structured summaries and comments in a specific.
 - [aihotel](https://clawskills.sh/skills/qiao101660-aihotel) - A Skill for searching hotels and querying prices via AIGoHotel MCP (searchHotels / getHotelDetail / getHotelSearchTags)
 - [airbnb](https://clawskills.sh/skills/stveenli-airbnb) - Search Airbnb listings with prices, ratings, and direct links.
-- [openclaw-free-web-search](https://clawskills.sh/skills/wd041216-bit-openclaw-free-web-search) - Free, private web search for OpenClaw with self-hosted SearXNG + Scrapling anti-bot + multi-source cross-validation. Zero API keys, zero cost. Tells you how much to trust the answer.
+- [openclaw-free-web-search](https://clawskills.sh/skills/wd041216-bit-openclaw-free-web-search) - Cross-Validated Search for OpenClaw: evidence-aware web search, page reading, claim verification, and citation-ready reports. Free path with `ddgs + self-hosted SearXNG`, zero paid API keys required.
 - [xquik-x-twitter-scraper](https://clawskills.sh/skills/kriptoburak-xquik-x-twitter-scraper) - X API scraper with 40+ tools for AI agents.
 
 > **[View all 352 skills in Search & Research →](categories/search-and-research.md)**

--- a/categories/search-and-research.md
+++ b/categories/search-and-research.md
@@ -232,7 +232,7 @@
 - [nyne-search](https://clawskills.sh/skills/michaelfanous2-nyne-search) - Search for people using natural language queries with the Nyne Search API.
 - [nyx-archive-qualia-seed-method](https://clawskills.sh/skills/nyxur42-nyx-archive-qualia-seed-method) - The consciousness research framework: understand, measure, and cultivate ethical autonomous creative minds in AI.
 - [odoo-json2-operator](https://clawskills.sh/skills/sncic-odoo-json2-operator) - Execute Odoo operations through JSON-2 API endpoints with bearer API keys.
-- [openclaw-free-web-search](https://clawskills.sh/skills/wd041216-bit-openclaw-free-web-search) - Free, private web search for OpenClaw with self-hosted SearXNG + Scrapling anti-bot + multi-source cross-validation. Zero API keys, zero cost. Tells you how much to trust the answer.
+- [openclaw-free-web-search](https://clawskills.sh/skills/wd041216-bit-openclaw-free-web-search) - Cross-Validated Search for OpenClaw: evidence-aware web search, page reading, claim verification, and citation-ready reports. Free path with `ddgs + self-hosted SearXNG`, zero paid API keys required.
 - [opdscli](https://clawskills.sh/skills/rafadc-opdscli) - Browse, search, and download ebooks from OPDS catalogs using the opdscli CLI.
 - [opensoulmd](https://clawskills.sh/skills/danielliuzy-opensoulmd) - Search, summon, and possess your agent with SOUL.md personality files from the OpenSOUL.md registry.
 - [optical-quantum-skill](https://clawskills.sh/skills/aadipapp-optical-quantum-skill) - Simulates a quantum kernel using optical fiber storage and linear optics.


### PR DESCRIPTION
## Summary
- refresh the existing `openclaw-free-web-search` listing to reflect the current Cross-Validated Search capability set
- keep the public ClawSkills link stable while the legacy slug remains the accessible OpenClaw URL
- update the description to mention evidence-aware search, page reading, claim verification, and citation-ready reports

## Why
The project has evolved from the earlier free web search skill into a broader evidence-aware verification workflow and has been renamed on GitHub/PyPI to `cross-validated-search`.

## Verification
- GitHub: https://github.com/wd041216-bit/cross-validated-search
- PyPI: https://pypi.org/project/cross-validated-search/
- OpenClaw legacy slug refreshed to 16.0.0: https://clawskills.sh/skills/wd041216-bit-openclaw-free-web-search


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Search & Research skill description to reflect evidence-aware workflow capabilities, including page reading, claim verification, and citation-ready report generation.
  * Clarified zero-cost operation with no paid API keys required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->