### PR TITLE
Add pharaoh — codebase knowledge graph with 23 skills

### DIFF
--- a/categories/coding-agents-and-ides.md
+++ b/categories/coding-agents-and-ides.md
@@ -731,6 +731,7 @@
 - [personality-switcher](https://clawskills.sh/skills/robb1010-personality-switcher) - Create and switch between AI assistant personalities.
 - [pest-disease-tracker](https://clawskills.sh/skills/johstracke-pest-disease-tracker) - Track garden pests and diseases with treatments.
 - [phenoskill](https://clawskills.sh/skills/kaichop-phenoskill) - Extract clinical phenotypes and medication entities from user-provided text using PhenoSnap, producing.
+- [pharaoh](https://clawhub.ai/pharaoh-so/pharaoh) - Codebase knowledge graph with 23 development workflow skills. Query architecture, dependencies, blast radius, dead code instead of reading files one at a time. MCP-native. `npx @pharaoh-so/mcp --install-skills`
 - [pi-workflow](https://clawskills.sh/skills/kai-tw-pi-workflow) - Workflow orchestration for Pi's task management, self-improvement, and code quality standards.
 - [pinchbench](https://clawskills.sh/skills/olearycrew-pinchbench) - Run PinchBench benchmarks to evaluate OpenClaw agent performance across real-world tasks.
 - [pixel-lobster](https://clawskills.sh/skills/joeproai-pixel-lobster) - Pixel art desktop lobster that lip-syncs to OpenClaw TTS speech.


### PR DESCRIPTION
Pharaoh maps codebases into queryable knowledge graphs for AI agents. Ships 23 battle-tested skills covering planning, debugging, TDD, code review, refactoring, health checks, and more.

- MCP-native, zero config
- Install: `npx @pharaoh-so/mcp --install-skills`
- ClawHub: https://clawhub.ai/0xuxdesign/pharaoh
- GitHub (OpenClaw skills repo): https://github.com/openclaw/skills/tree/main/skills/pharaoh-so/pharaoh (PR pending: https://github.com/openclaw/skills/pull/246)
- Homepage: https://pharaoh.so

### Community usage
- Used across 29+ tenant organizations
- Multi-agent playbooks: https://pharaoh.so/docs/guides/multi-agent-teams
- Example repo: https://github.com/Pharaoh-so/taskflow-api
- AI Code Quality Framework integration: https://github.com/0xUXDesign/ai-code-quality-framework