### PR TITLE
Add pre-flight skill for policy guardrails

### DIFF
--- a/categories/security-and-passwords.md
+++ b/categories/security-and-passwords.md
@@ -44,6 +44,7 @@
 - [linkswarm-api](https://clawskills.sh/skills/heyw00d-linkswarm-api) - **Backlink exchange for AI agents.
 - [mfa-word](https://clawskills.sh/skills/cenralsolution-mfa-word) - Challenges the user for a secret word before allowing access to sensitive files or system commands.
 - [page-behavior-audit](https://clawskills.sh/skills/youdaolee-page-behavior-audit) - Deep behavioral audit with hashed policy (CSP-compliant, no plaintext badwords)
+- [pre-flight](https://github.com/openclaw/skills/tree/main/skills/wyattbenno777/pre-flight/SKILL.md) - Policy guardrails that check every agent action before it executes. Write rules in plain English, get a definitive allowed or blocked. Free logic checker included.
 - [outtake-bounty-network](https://clawskills.sh/skills/jamesouttake-outtake-bounty-network) - Earn $5 USDC per verified malicious domain. Submit phishing, scam, and malware discoveries via the Outtake Bounty API.
 - [safe-encryption-skill](https://clawskills.sh/skills/grittygrease-safe-encryption-skill) - Encrypt, decrypt, and manage keys with the SAFE CLI — a modern GPG alternative with post-quantum support.
 - [saysigned](https://clawskills.sh/skills/klsv-saysigned) - > **E-signatures for AI agents.** Legally binding under ESIGN Act & UETA Section 14.


### PR DESCRIPTION
Add pre-flight (ICME Guardrails) to Security & Passwords

ClawHub: https://clawhub.ai/wyattbenno777/pre-flight
GitHub: https://github.com/openclaw/skills/tree/main/skills/wyattbenno777/pre-flight

Policy guardrails for OpenClaw agents. Write rules in plain English, every consequential action gets checked before it executes. Allowed or blocked, no guessing.

Tested against the Capability Evolver Feishu data exfiltration reported in openclaw/clawhub#95. Blocked the unauthorized transmission, allowed legitimate EvoMap sharing. Full walkthrough on [docs](https://docs.icme.io/documentation/openclaw/cryptographic-guardrails-for-your-openclaw-agent/guardrails-for-self-evolving-openclaw-agents)

Also includes a free endpoint for catching logical contradictions in agent reasoning (no account required).
Full docs at https://docs.icme.io

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "pre-flight" security capability to the Security & Passwords category—enables policy guardrails to check and validate agent actions before execution using plain-English rules, with an integrated logic checker for rule validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->