### PR TITLE
Add skill: claw-setup-configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 | [Image & Video Generation](#image--video-generation) (170) | [Media & Streaming](#media--streaming) (85) | [PDF & Documents](#pdf--documents) (105) |
 | [Apple Apps & Services](#apple-apps--services) (44) | [Notes & PKM](#notes--pkm) (70) | [Self-Hosted & Automation](#self-hosted--automation) (33) |
 | [Search & Research](#search--research) (345) | [iOS & macOS Development](#ios--macos-development) (29) | [Security & Passwords](#security--passwords) (53) |
-| [Clawdbot Tools](#clawdbot-tools) (37) | [Transportation](#transportation) (110) | [Moltbook](#moltbook) (29) |
+| [Clawdbot Tools](#clawdbot-tools) (38) | [Transportation](#transportation) (110) | [Moltbook](#moltbook) (29) |
 | [CLI Utilities](#cli-utilities) (180) | [Personal Development](#personal-development) (50) | [Gaming](#gaming) (35) |
 | [Health & Fitness](#health--fitness) (87) | | |
 
@@ -476,6 +476,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [claude-connect](https://clawskills.sh/skills/tunaissacoding-claude-connect) - Connect Claude to Clawdbot instantly and keep.
 - [clauditor](https://clawskills.sh/skills/apollostreetcompany-clauditor) - Tamper-resistant audit watchdog for Clawdbot agents.
 - [claw-face](https://clawskills.sh/skills/mkoslacz-claw-face) - Floating avatar widget for AI agents showing emotions, actions.
+- [claw-setup-configuration](https://github.com/openclaw/skills/tree/main/skills/radelqui/claw-setup-configuration/SKILL.md) - Configure OpenClaw AI assistant — model chain, providers, and workspace files.
 - [clawd-coach](https://clawskills.sh/skills/shiv19-clawd-coach) - Create personalized triathlon, marathon, and ultra-endurance training.
 - [clawd-modifier](https://clawskills.sh/skills/masonc15-clawd-modifier) - Modify Clawd, the Claude Code mascot.
 - [clawd-presence](https://clawskills.sh/skills/voidcooks-clawd-presence) - Physical presence display for AI agents.
@@ -489,7 +490,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [clawdirect-dev](https://clawskills.sh/skills/napoleond-clawdirect-dev) - Build agent-facing web experiences with ATXP-based.
 - [honcho-setup](https://clawskills.sh/skills/ajspig-honcho-setup) - Persistent cross-session memory via Honcho.
 
-> **[View all 37 skills in Clawdbot Tools →](categories/clawdbot-tools.md)**
+> **[View all 38 skills in Clawdbot Tools →](categories/clawdbot-tools.md)**
 </details>
 
 <details>


### PR DESCRIPTION
## Summary

Adding `claw-setup-configuration` to the **Clawdbot Tools** section.

**What it does:** Guided configuration assistant for OpenClaw AI assistant setup — model chain, provider credentials, SOUL.md/USER.md/IDENTITY.md workspace files, gateway, cron, and webhook settings.

**Links:**
- GitHub (canonical): https://github.com/openclaw/skills/tree/main/skills/radelqui/claw-setup-configuration/SKILL.md
- Upstream PR to openclaw/skills: https://github.com/openclaw/skills/pull/248

## Changes

- Added entry for `claw-setup-configuration` in **Clawdbot Tools** section (alphabetical order, between `claw-face` and `clawd-coach`)
- Updated Clawdbot Tools count in Table of Contents: 37 → 38
- Updated "View all N skills" footer in Clawdbot Tools section: 37 → 38
- Used canonical `github.com/openclaw/skills/tree/main/skills/...` URL format per CONTRIBUTING.md

## Fixes vs PR #293

This PR corrects the issues from the previously closed PR #293:
1. Correct section: **Clawdbot Tools** (not iOS & macOS Development)
2. Canonical URL: `github.com/openclaw/skills/...` (not personal repo)
3. Count updated: Clawdbot Tools 37 → 38
4. New skill name: `claw-setup-configuration` (not `openclaw-expert-brain`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "claw-setup-configuration" skill documentation to Clawdbot Tools.
  * Updated tools count and navigation links to reflect the new skill.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->