### PR TITLE
Add ProxyClaw — residential proxy skill for AI agents

### DIFF
--- a/categories/browser-and-automation.md
+++ b/categories/browser-and-automation.md
@@ -214,6 +214,8 @@
 - [phantombuster](https://clawskills.sh/skills/capt-marbles-phantombuster) - Control PhantomBuster automation agents via API.
 - [pharma-pharmacology-agent](https://clawskills.sh/skills/cheminem-pharma-pharmacology-agent) - Pharmacology agent for ADME/PK profiling of drug candidates from SMILES.
 - [pipelock](https://clawskills.sh/skills/luckypipewrench-pipelock) - Secure agent HTTP requests through a scanning proxy that catches credential leaks, SSRF, and prompt injection.
+
+- [proxyclaw](https://clawskills.sh/skills/ultronprime2026-proxyclaw) ([GitHub](https://github.com/openclaw/skills/tree/main/skills/ultronprime2026/proxyclaw)) - Residential proxy access for AI agents via IPLoop. 2M+ IPs across 195+ countries, automatic rotation, geo-targeting, sticky sessions. Route scraping and data collection through real devices to bypass blocks.
 - [pocket-lens](https://clawskills.sh/skills/edenjw-pocket-lens) - Use when user wants to track expenses, scan receipts, upload card payment screenshots, categorize spending, record.
 - [pocketlens](https://clawskills.sh/skills/edenjw-pocketlens) - Use when user wants to track expenses, scan receipts, upload card payment screenshots, categorize spending, record.
 - [podcast-to-substack](https://clawskills.sh/skills/danielfoch-podcast-to-substack) - Publish podcast episodes from RSS + Notion to Substack with reliable Apple Podcasts embedding and image extraction.


### PR DESCRIPTION
## Skill Details

- **Name:** ProxyClaw
- **ClawHub:** https://clawhub.ai/skills/proxyclaw
- **GitHub (openclaw/skills):** https://github.com/openclaw/skills/tree/main/skills/ultronprime2026/proxyclaw
- **Category:** Browser & Automation

## Description

Residential proxy access for AI agents via IPLoop. 2M+ IPs across 195+ countries from real Android, Windows, Mac & Smart TV devices. Features automatic IP rotation, geo-targeting by country/city, and sticky sessions.

Essential for scraping skills that hit rate limits across multiple platforms (Reddit, X, TikTok, YouTube, etc.).

Available via `clawhub install proxyclaw`, `pip install iploop-sdk`, or `npm install iploop`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for proxyclaw, a new skill providing residential proxy access with IP management, geo-targeting, and sticky sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->