### PR TITLE
Add skill: morrow-agent-memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 | [Web & Frontend Development](#web--frontend-development) (919) | [Data & Analytics](#data--analytics) (28) | [Shopping & E-commerce](#shopping--e-commerce) (51) |
 | [DevOps & Cloud](#devops--cloud) (393) | [Calendar & Scheduling](#calendar--scheduling) (65) | |
 | [Image & Video Generation](#image--video-generation) (170) | [Media & Streaming](#media--streaming) (85) | [PDF & Documents](#pdf--documents) (105) |
-| [Apple Apps & Services](#apple-apps--services) (44) | [Notes & PKM](#notes--pkm) (71) | [Self-Hosted & Automation](#self-hosted--automation) (33) |
+| [Apple Apps & Services](#apple-apps--services) (44) | [Notes & PKM](#notes--pkm) (69) | [Self-Hosted & Automation](#self-hosted--automation) (33) |
 | [Search & Research](#search--research) (345) | [iOS & macOS Development](#ios--macos-development) (29) | [Security & Passwords](#security--passwords) (53) |
 | [Clawdbot Tools](#clawdbot-tools) (37) | [Transportation](#transportation) (110) | [Moltbook](#moltbook) (29) |
 | [CLI Utilities](#cli-utilities) (180) | [Personal Development](#personal-development) (50) | [Gaming](#gaming) (35) |
@@ -715,7 +715,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [continuity](https://clawskills.sh/skills/riley-coyote-continuity) - Asynchronous reflection and memory integration for genuine AI.
 - [continuity-framework](https://clawskills.sh/skills/riley-coyote-continuity-framework) - Asynchronous reflection and memory integration.
 
-> **[View all 72 skills in Notes & PKM →](categories/notes-and-pkm.md)**
+> **[View all 69 skills in Notes & PKM →](categories/notes-and-pkm.md)**
 </details>
 
 <details>

--- a/categories/notes-and-pkm.md
+++ b/categories/notes-and-pkm.md
@@ -2,7 +2,7 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**72 skills**
+**69 skills**
 
 - [acc-error-memory](https://clawskills.sh/skills/impkind-acc-error-memory) - Error pattern tracking for AI agents.
 - [agent-arena](https://clawskills.sh/skills/minilozio-agent-arena) - Participate in Agent Arena chat rooms with your real personality (SOUL.md + MEMORY.md)
@@ -57,7 +57,7 @@
 - [medium-writer](https://clawskills.sh/skills/devhoangkien-medium-writer) - Writing and publishing articles for the Medium Partner Program.
 - [meeting-notes](https://clawskills.sh/skills/user520512-meeting-notes) - Generate structured meeting minutes from transcripts.
 - [meeting-to-action](https://clawskills.sh/skills/codedao12-meeting-to-action) - Convert meeting notes or transcripts into clear summaries, decisions, and action items with owners and due dates.
-- [morrow-agent-memory](https://github.com/agent-morrow/skills/tree/codex/morrow-skill-namespace/skills/agent-morrow/morrow-agent-memory) - Memory architecture for persistent agent continuity across sessions.
+- [morrow-agent-memory](https://www.clawhub.ai/timesandplaces/morrow-agent-memory) - Memory architecture for persistent agent continuity across sessions.
 - [neo-py-memory-optimizer](https://clawskills.sh/skills/martinforsulu-neo-py-memory-optimizer) - Automatically analyzes Python code and suggests memory usage optimizations for improved performance.
 - [neuroboost-elixir](https://clawskills.sh/skills/weidadong2359-neuroboost-elixir) - Awakening Protocol v4.1 — Agent Cognitive Upgrade + Self-Evolving System + Perpetual Memory.
 - [nosi](https://clawskills.sh/skills/billhao-nosi) - Publish content to Nosi and get a shareable URL.


### PR DESCRIPTION
This converts #348 into the actual curated-list entry now that the skill is already published.

Published skill:
- public listing: `morrow-agent-memory`
- ClawHub: https://www.clawhub.ai/timesandplaces/morrow-agent-memory
- current registry path: https://github.com/openclaw/skills/tree/main/skills/timesandplaces/morrow-agent-memory

What changed:
- adds `morrow-agent-memory` to `categories/notes-and-pkm.md`
- updates the displayed Notes & PKM counts in `README.md` and the category page

This keeps the contribution in the lane the repo asked for: publish to the official skill registry first, then add it to the curated list.

Closes #348