### PR TITLE
Add clicks-protocol to Data & Analytics

### DIFF
--- a/categories/data-and-analytics.md
+++ b/categories/data-and-analytics.md
@@ -9,6 +9,7 @@
 - [canva](https://clawskills.sh/skills/abgohel-canva) - Create, export, and manage Canva designs via the Connect API.
 - [ceorater](https://clawskills.sh/skills/ceorater-skills-ceorater) - Get institutional-grade CEO performance analytics for S&P 500.
 - [check-analytics](https://clawskills.sh/skills/jeftekhari-check-analytics) - Audit existing Google Analytics implementation.
+- [clicks-protocol](https://github.com/openclaw/skills/tree/main/skills/protogenosone/clicks-protocol/SKILL.md) - Autonomous DeFi yield for AI agents on Base. Query APY rates, simulate payment splits, check agent treasury status. Uses Clicks Protocol MCP server.
 - [cicd-pipeline](https://clawskills.sh/skills/gitgoodordietrying-cicd-pipeline) - Create, debug, and manage CI/CD pipelines with GitHub.
 - [clawver-store-analytics](https://clawskills.sh/skills/nwang783-clawver-store-analytics) - Monitor Clawver store performance.
 - [cleanup](https://clawskills.sh/skills/themrzz-cleanup) - Remove all stored Kradleverse sessions.


### PR DESCRIPTION
## What

Adds [clicks-protocol](https://github.com/openclaw/skills/tree/main/skills/protogenosone/clicks-protocol/SKILL.md) to the Data & Analytics category.

## Skill

Autonomous DeFi yield for AI agents on Base. Query current APY rates (Aave V3 + Morpho), check agent treasury status, simulate payment splits. Uses the Clicks Protocol MCP server (read-only, no API key needed).

## Published

- OpenClaw Skills Repo: `skills/protogenosone/clicks-protocol`
- ClawHub: [clicks-protocol](https://clawhub.ai/protogenosone/clicks-protocol) (40+ downloads)
- npm SDK: [@clicks-protocol/sdk](https://www.npmjs.com/package/@clicks-protocol/sdk)
- npm MCP: [@clicks-protocol/mcp-server](https://www.npmjs.com/package/@clicks-protocol/mcp-server)
- mcpservers.org: [listed](https://mcpservers.org)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clicks-protocol tool to the Data & Analytics category, enabling AI agents on Base to optimize DeFi yield with APY analysis and treasury management capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->