### PR TITLE
Add skill: ninihen1/power-automate-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,10 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [agentkeys](https://clawskills.sh/skills/alexandr-belogubov-agentkeys) - Secure credential proxy for AI agents.
 - [agentmemory](https://clawskills.sh/skills/badaramoni-agentmemory) - End-to-end encrypted cloud memory for AI agents.
 
-> **[View all 392 skills in DevOps & Cloud →](categories/devops-and-cloud.md)**
+- [power-automate-build](https://clawskills.sh/skills/ninihen1-power-automate-build) - Build and deploy Power Automate flows from scratch.
+- [power-automate-debug](https://clawskills.sh/skills/ninihen1-power-automate-debug) - Step-by-step debugging for failing Power Automate flows.
+- [power-automate-mcp](https://clawskills.sh/skills/ninihen1-power-automate-mcp) - Read, debug, and modify Power Automate flows via MCP.
+> **[View all 395 skills in DevOps & Cloud →](categories/devops-and-cloud.md)**
 </details>
 
 <details>


### PR DESCRIPTION
Three Power Automate skills for AI agents via FlowStudio MCP server.

- **power-automate-mcp** — Read, debug, and modify Power Automate flows via MCP
- **power-automate-debug** — Step-by-step debugging for failing Power Automate flows
- **power-automate-build** — Build and deploy Power Automate flows from scratch

**ClawHub:** https://clawhub.ai/ninihen1/power-automate-mcp
**GitHub:** https://github.com/ninihen1/FlowStudio-MCP/tree/master/skills/power-automate-mcp
**OpenClaw repo:** https://github.com/openclaw/skills/tree/main/skills/ninihen1

Published as v1.1.0 on ClawHub. 3K+ installs on skills.sh via awesome-copilot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added three new Power Automate skills to the DevOps & Cloud section, covering build automation, debugging, and management capabilities.
  * Updated total skills count to 395.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->