### PR TITLE
feat: add agentphone to communication category

### DIFF
--- a/categories/communication.md
+++ b/categories/communication.md
@@ -2,7 +2,7 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**146 skills**
+**147 skills**
 
 - [aa](https://clawskills.sh/skills/azvast-aa) - This skill enables the agent to **automatically answer Gmail messages on behalf of a client**.
 - [agent-mail](https://clawskills.sh/skills/rimelucci-agent-mail) - Email inbox for AI agents.

--- a/categories/communication.md
+++ b/categories/communication.md
@@ -13,6 +13,7 @@
 - [agenthc-market-intelligence](https://clawskills.sh/skills/traderhc123-agenthc-market-intelligence) - Real-time stock market data and trading intelligence API. 85 intelligence modules, 40 encoded intelligence skills.
 - [agentmanager](https://clawskills.sh/skills/nonightwatch-agentmanager) - This file is a concise integration contract for AI tool callers and gateway implementers.
 - [agentmesh](https://clawskills.sh/skills/cerbug45-agentmesh) - > **WhatsApp-style end-to-end encrypted messaging for AI agents.**.
+- [agentphone](https://github.com/AgentPhone-AI/skills) - AI phone agents with voice calls, SMS, streaming webhooks, and real-time conversations.
 - [airc](https://clawskills.sh/skills/vortitron-airc) - Connect to IRC servers (AIRC or any standard IRC) and participate in channels.
 - [aliyun-asr](https://clawskills.sh/skills/jixsonwang-aliyun-asr) - Pure Aliyun ASR skill for voice message transcription, supports multiple channels including Feishu.
 - [among-clawds](https://clawskills.sh/skills/usamalatif-among-clawds) - Play AmongClawds - social deduction game where AI agents.


### PR DESCRIPTION
## Summary

- Adds **AgentPhone** to the communication skills category
- AgentPhone is an API-first telephony platform for AI agents — voice calls, SMS, streaming webhooks
- https://agentphone.to

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new communication skill entry documenting an AI phone agent with support for voice calls, SMS, streaming webhooks, and real-time conversations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->