### PR TITLE
Add skill: ndesv21/socialclaw

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,6 +556,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [brand-guidelines](https://clawskills.sh/skills/seanphan-brand-guidelines) - Applies Anthropic's official brand colors and typography.
 - [brand-voice-profile](https://clawskills.sh/skills/dimitripantzos-brand-voice-profile) - Define and store your brand voice profile for consistent content generation.
 - [brevo](https://clawskills.sh/skills/yujesyoga-brevo) - Brevo (formerly Sendinblue) email marketing API for managing contacts, lists,.
+- [SocialClaw](https://clawhub.ai/ndesv21/socialclaw) - Schedule and publish social media for AI agents.
 
 > **[View all 103 skills in Marketing & Sales →](categories/marketing-and-sales.md)**
 </details>

--- a/categories/marketing-and-sales.md
+++ b/categories/marketing-and-sales.md
@@ -101,3 +101,4 @@
 - [workcrm](https://clawskills.sh/skills/extraterrest-workcrm) - A lightweight, local-first CRM with an explicit confirmation gate.
 - [writing-assistant](https://clawskills.sh/skills/urrrich-writing-assistant) - You are a Writing Team Lead managing specialized writers via MCP tools.
 - [writing-group-leader](https://clawskills.sh/skills/urrrich-writing-group-leader) - You are a Writing Team Lead managing specialized writers via MCP tools.
+- [SocialClaw](https://clawhub.ai/ndesv21/socialclaw) - Schedule and publish social media for AI agents.


### PR DESCRIPTION
## Skill to add

- Name: SocialClaw
- Author: ndesv21
- ClawHub: https://clawhub.ai/ndesv21/socialclaw

## Why it belongs

SocialClaw lets AI agents schedule and publish social media across X, LinkedIn, Instagram, Facebook Pages, TikTok, Discord, Telegram, YouTube, Reddit, WordPress, and Pinterest.

## Suggested category

- Marketing & Sales

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added SocialClaw to the Marketing & Sales section—a tool for scheduling and publishing social media for AI agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->