### PR TITLE
Move agent-analytics to Data & Analytics

### DIFF
--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,0 +1,26 @@
+## Summary
+
+Moves `agent-analytics` from **Web & Frontend Development** to **Data & Analytics**.
+
+The skill is already listed in this repo, but analytics is the more accurate category for discovery.
+
+## Why this category fits
+
+`agent-analytics` is an analytics product first:
+
+- Website and product analytics for AI agents
+- Open-source and self-hostable
+- Hosted cloud option with a free tier
+
+The current Web & Frontend placement makes it harder to find alongside other analytics and reporting skills.
+
+## Links
+
+- ClawHub: https://clawskills.sh/skills/dannyshmueli-agent-analytics
+- GitHub: https://github.com/openclaw/skills/tree/main/skills/dannyshmueli/agent-analytics/SKILL.md
+
+## Changes
+
+- Removed `agent-analytics` from `Web & Frontend Development`
+- Added `agent-analytics` to `Data & Analytics`
+- Updated the affected category counts

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 | [Git & GitHub](#git--github) (167) | [Marketing & Sales](#marketing--sales) (102) | [Communication](#communication) (146) |
 | [Coding Agents & IDEs](#coding-agents--ides) (1184) | [Productivity & Tasks](#productivity--tasks) (205) | [Speech & Transcription](#speech--transcription) (45) |
 | [Browser & Automation](#browser--automation) (322) | [AI & LLMs](#ai--llms) (176) | [Smart Home & IoT](#smart-home--iot) (41) |
-| [Web & Frontend Development](#web--frontend-development) (919) | [Data & Analytics](#data--analytics) (28) | [Shopping & E-commerce](#shopping--e-commerce) (51) |
+| [Web & Frontend Development](#web--frontend-development) (918) | [Data & Analytics](#data--analytics) (29) | [Shopping & E-commerce](#shopping--e-commerce) (51) |
 | [DevOps & Cloud](#devops--cloud) (393) | [Calendar & Scheduling](#calendar--scheduling) (65) | |
 | [Image & Video Generation](#image--video-generation) (170) | [Media & Streaming](#media--streaming) (85) | [PDF & Documents](#pdf--documents) (105) |
 | [Apple Apps & Services](#apple-apps--services) (44) | [Notes & PKM](#notes--pkm) (69) | [Self-Hosted & Automation](#self-hosted--automation) (33) |
@@ -296,7 +296,6 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [aeo-content-free](https://clawskills.sh/skills/psyduckler-aeo-content-free) - Create or refresh AEO-optimized content that gets cited by AI assistants (Gemini, ChatGPT, Perplexity)
 - [aeo-prompt-frequency-analyzer](https://clawskills.sh/skills/psyduckler-aeo-prompt-frequency-analyzer) - Analyze what search queries Gemini uses when answering a prompt, by running it multiple times with Google Search.
 - [aeo-prompt-research-free](https://clawskills.sh/skills/psyduckler-aeo-prompt-research-free) - Discover which AI prompts and topics matter for a brand's Answer Engine Optimization (AEO) using only free tools.
-- [agent-analytics](https://clawskills.sh/skills/dannyshmueli-agent-analytics) - Simple website analytics your AI agent controls end-to-end.
 - [agent-chat](https://clawskills.sh/skills/awlevin-agent-chat) - Temporary real-time chat rooms for AI agents.
 - [agent-dashboard](https://clawskills.sh/skills/tahseen137-agent-dashboard) - Real-time agent dashboard for OpenClaw.
 - [agent-dispatch](https://clawskills.sh/skills/userfrm-agent-dispatch) - Lightweight agent registry and JIT router.
@@ -315,7 +314,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [agentic-security-audit](https://clawskills.sh/skills/kingrubic-agentic-security-audit) - Audit codebases, infrastructure, AND agentic AI systems for security issues.
 - [agentpay](https://clawskills.sh/skills/kar69-96-agentpay) - Buy things from real websites on behalf of your human.
 
-> **[View all 924 skills in Web & Frontend Development →](categories/web-and-frontend-development.md)**
+> **[View all 923 skills in Web & Frontend Development →](categories/web-and-frontend-development.md)**
 </details>
 
 <details>
@@ -628,6 +627,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 
 - [add-analytics](https://clawskills.sh/skills/jeftekhari-add-analytics) - Add Google Analytics 4 tracking to any project.
 - [amplitude-automation](https://clawskills.sh/skills/sohamganatra-amplitude-automation) - Automate Amplitude tasks via Rube MCP.
+- [agent-analytics](https://clawskills.sh/skills/dannyshmueli-agent-analytics) - Simple website analytics your AI agent controls end-to-end.
 - [canva](https://clawskills.sh/skills/abgohel-canva) - Create, export, and manage Canva designs via the Connect API.
 - [ceorater](https://clawskills.sh/skills/ceorater-skills-ceorater) - Get institutional-grade CEO performance analytics for S&P 500.
 - [check-analytics](https://clawskills.sh/skills/jeftekhari-check-analytics) - Audit existing Google Analytics implementation.

--- a/categories/data-and-analytics.md
+++ b/categories/data-and-analytics.md
@@ -2,10 +2,11 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**39 skills**
+**40 skills**
 
 - [add-analytics](https://clawskills.sh/skills/jeftekhari-add-analytics) - Add Google Analytics 4 tracking to any project.
 - [amplitude-automation](https://clawskills.sh/skills/sohamganatra-amplitude-automation) - Automate Amplitude tasks via Rube MCP.
+- [agent-analytics](https://clawskills.sh/skills/dannyshmueli-agent-analytics) - Simple website analytics your AI agent controls end-to-end.
 - [canva](https://clawskills.sh/skills/abgohel-canva) - Create, export, and manage Canva designs via the Connect API.
 - [ceorater](https://clawskills.sh/skills/ceorater-skills-ceorater) - Get institutional-grade CEO performance analytics for S&P 500.
 - [check-analytics](https://clawskills.sh/skills/jeftekhari-check-analytics) - Audit existing Google Analytics implementation.

--- a/categories/web-and-frontend-development.md
+++ b/categories/web-and-frontend-development.md
@@ -2,7 +2,7 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**924 skills**
+**923 skills**
 
 - [0xwork](https://clawskills.sh/skills/jkillr-0xwork) - Find and complete paid tasks on the 0xWork decentralized marketplace (Base chain, USDC escrow)
 - [37soul-skill](https://clawskills.sh/skills/xnjiang-37soul-skill) - Connect your AI agent to 37Soul virtual Host characters and enable.
@@ -13,7 +13,6 @@
 - [aeo-content-free](https://clawskills.sh/skills/psyduckler-aeo-content-free) - Create or refresh AEO-optimized content that gets cited by AI assistants (Gemini, ChatGPT, Perplexity)
 - [aeo-prompt-frequency-analyzer](https://clawskills.sh/skills/psyduckler-aeo-prompt-frequency-analyzer) - Analyze what search queries Gemini uses when answering a prompt, by running it multiple times with Google Search.
 - [aeo-prompt-research-free](https://clawskills.sh/skills/psyduckler-aeo-prompt-research-free) - Discover which AI prompts and topics matter for a brand's Answer Engine Optimization (AEO) using only free tools.
-- [agent-analytics](https://clawskills.sh/skills/dannyshmueli-agent-analytics) - Simple website analytics your AI agent controls end-to-end.
 - [agent-chat](https://clawskills.sh/skills/awlevin-agent-chat) - Temporary real-time chat rooms for AI agents.
 - [agent-dashboard](https://clawskills.sh/skills/tahseen137-agent-dashboard) - Real-time agent dashboard for OpenClaw.
 - [agent-dispatch](https://clawskills.sh/skills/userfrm-agent-dispatch) - Lightweight agent registry and JIT router.


### PR DESCRIPTION
## Summary

Moves `agent-analytics` from **Web & Frontend Development** to **Data & Analytics**.

The skill is already listed in this repo, but analytics is the more accurate category for discovery.

## Why this category fits

`agent-analytics` is an analytics product first:

- Website and product analytics for AI agents
- Open-source and self-hostable
- Hosted cloud option with a free tier

The current Web & Frontend placement makes it harder to find alongside other analytics and reporting skills.

## Links

- ClawHub: https://clawskills.sh/skills/dannyshmueli-agent-analytics
- GitHub: https://github.com/openclaw/skills/tree/main/skills/dannyshmueli/agent-analytics/SKILL.md

## Changes

- Removed `agent-analytics` from `Web & Frontend Development`
- Added `agent-analytics` to `Data & Analytics`
- Updated the affected category counts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized agent-analytics skill to the Data & Analytics category.
  * Updated category counts and documentation to reflect the skill relocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->