### PR TITLE
Add skill: abu-shotai/ai-video-remix

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [ai-headshot-generation](https://clawskills.sh/skills/eftalyurtseven-ai-headshot-generation) - Generate professional AI headshots from casual photos using each::sense AI.
 - [ai-persona-engine](https://clawskills.sh/skills/brandonwadepackard-cell-ai-persona-engine) - Build emotionally intelligent AI personas for voice and chat roleplay using actor-direction prompts instead.
 - [ai-video-gen](https://clawskills.sh/skills/rhanbourinajd-ai-video-gen) - End-to-end AI video generation - create videos from text.
+- [ai-video-remix](https://clawskills.sh/skills/abu-shotai-ai-video-remix) - AI video remix with Remotion and ShotAI MCP.
 - [aikek](https://clawskills.sh/skills/vvsotnikov-aikek) - Access AIKEK APIs for crypto/DeFi research and image generation.
 - [aiusd](https://clawskills.sh/skills/chaunceyliu-aiusd) - AIUSD trading and account management skill.
 - [aiusd-skills](https://clawskills.sh/skills/chaunceyliu-aiusd-skills) - AIUSD trading and account management skill.


### PR DESCRIPTION
## Summary
Add `ai-video-remix` to the Image & Video Generation category.

## Skill
- ClawHub: https://clawhub.ai/abu-shotai/ai-video-remix
- GitHub: https://github.com/openclaw/skills/tree/main/skills/abu-shotai/ai-video-remix

## README entry
- [ai-video-remix](https://clawskills.sh/skills/abu-shotai-ai-video-remix) - AI video remix with Remotion and ShotAI MCP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new skill entry for AI video generation to the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->