### PR TITLE
Add 'nex-life-logger' to productivity and tasks

### DIFF
--- a/categories/productivity-and-tasks.md
+++ b/categories/productivity-and-tasks.md
@@ -132,6 +132,7 @@
 - [neural-memory](https://clawskills.sh/skills/nhadaututtheky-neural-memory) - Associative memory with spreading activation for persistent, intelligent recall.
 - [newhorse](https://clawskills.sh/skills/xcrong-newhorse) - NewHorse AI Agent Competition Platform.
 - [ng-lawyer-db-build](https://clawskills.sh/skills/gfly0424-maker-ng-lawyer-db-build) - This is **Step 1** of Fei Gao’s “Nigeria Lawyer Network” workflow:.
+- [nex-life-logger](https://clawskills.sh/skills/nexaiguy-nex-life-logger) - AI-powered local activity tracker. Tracks browser history, active windows, and YouTube transcripts. Query your computer history through your agent. Privacy-first, all data stays on your machine.
 - [og-board-individual](https://clawskills.sh/skills/jatin-31-og-board-individual) - Use when you need to work with tasks: view tasks, list tasks, update task status, add blockers, artifacts, and worklogs.
 - [ogt-docs-create](https://clawskills.sh/skills/eduardou24-ogt-docs-create) - Create new documentation entities in the docs-first system.
 - [openburn](https://clawskills.sh/skills/logesh2496-openburn) - Automates collecting Pump.fun creator fees, buying tokens with collected SOL, and burning those tokens (buyback.


### PR DESCRIPTION
Adds [nex-life-logger](https://clawskills.sh/skills/nexaiguy-nex-life-logger) to the Productivity & Tasks category.

AI-powered local activity tracker that logs browser history, active windows, and YouTube transcripts. Users can query their computer history through their OpenClaw agent. All data stays local for privacy.

- ClawHub: https://clawskills.sh/skills/nexaiguy-nex-life-logger
- GitHub: https://github.com/NexaiGuy/nex-life-logger

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for a new AI-powered activity tracking tool with local browser history tracking, active window monitoring, and YouTube transcript query capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->