### PR TITLE
Add skill: ninihen1/power-automate-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [agentmemory](https://clawskills.sh/skills/badaramoni-agentmemory) - End-to-end encrypted cloud memory for AI agents.
 
 - [ninihen1](https://github.com/openclaw/skills/tree/main/skills/ninihen1) - Power Automate flow operations, debugging, and building via MCP.
-> **[View all 392 skills in DevOps & Cloud →](categories/devops-and-cloud.md)**
+> **[View all 393 skills in DevOps & Cloud →](categories/devops-and-cloud.md)**
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [agentkeys](https://clawskills.sh/skills/alexandr-belogubov-agentkeys) - Secure credential proxy for AI agents.
 - [agentmemory](https://clawskills.sh/skills/badaramoni-agentmemory) - End-to-end encrypted cloud memory for AI agents.
 
+- [ninihen1](https://github.com/openclaw/skills/tree/main/skills/ninihen1) - Power Automate flow operations, debugging, and building via MCP.
 > **[View all 392 skills in DevOps & Cloud →](categories/devops-and-cloud.md)**
 </details>
 


### PR DESCRIPTION
Single author entry for three Power Automate skills via FlowStudio MCP.

- https://clawhub.ai/ninihen1/power-automate-mcp
- https://github.com/openclaw/skills/tree/main/skills/ninihen1

All three skills (power-automate-mcp, power-automate-debug, power-automate-build) are published in the official OpenClaw skills repo under ninihen1/. Bundled as one author entry per contributing guidelines.

Published as v1.1.0 on ClawHub (221 downloads). Security status: Benign.