### PR TITLE
Add Postiz Agent — Social Media Scheduling Skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,6 +556,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [brand-guidelines](https://clawskills.sh/skills/seanphan-brand-guidelines) - Applies Anthropic's official brand colors and typography.
 - [brand-voice-profile](https://clawskills.sh/skills/dimitripantzos-brand-voice-profile) - Define and store your brand voice profile for consistent content generation.
 - [brevo](https://clawskills.sh/skills/yujesyoga-brevo) - Brevo (formerly Sendinblue) email marketing API for managing contacts, lists,.
+- [postiz-agent](https://github.com/gitroomhq/postiz-agent) - Schedule social media posts and threads across 28+ platforms.
 
 > **[View all 103 skills in Marketing & Sales →](categories/marketing-and-sales.md)**
 </details>

--- a/categories/marketing-and-sales.md
+++ b/categories/marketing-and-sales.md
@@ -82,6 +82,7 @@
 - [pilt](https://clawskills.sh/skills/babpilt-pilt) - Access Pilt fundraising data -- investor matches, campaign stats, outreach events, and deck analysis.
 - [posthog](https://clawskills.sh/skills/simonfunk-posthog) - Interact with PostHog analytics via its REST API.
 - [posthog-query](https://clawskills.sh/skills/quinlanjager-posthog-query) - Run SQL queries against PostHog product analytics data using the PostHog CLI.
+- [postiz-agent](https://github.com/gitroomhq/postiz-agent) - Schedule social media posts and threads across 28+ platforms.
 - [reef-copywriting](https://clawskills.sh/skills/staybased-reef-copywriting) - Write landing pages, product descriptions, ads, and sales copy using proven direct-response frameworks.
 - [ryot](https://clawskills.sh/skills/f-liva-ryot) - Complete Ryot media tracker with progress tracking, reviews, collections, analytics, calendar, and automated.
 - [sentiment-priority-scorer](https://clawskills.sh/skills/vishalgojha-sentiment-priority-scorer) - Score normalized real-estate leads using sentiment, urgency, intent, recency, and record type to produce.


### PR DESCRIPTION
Add Postiz Agent skill to Marketing & Sales category.

- **GitHub:** https://github.com/gitroomhq/postiz-agent
- **npm:** [postiz](https://www.npmjs.com/package/postiz)
- **Website:** https://postiz.com
- **ClawHub**: https://www.clawhub.ai/nevo-david/postiz
- **Current registry path**: https://github.com/openclaw/skills/tree/main/skills/nevo-david/postiz

Schedule social media posts and threads across 28+ platforms (X, LinkedIn, Reddit, YouTube, TikTok, Instagram, and more) from the CLI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "postiz-agent" entry to the Marketing & Sales skill list (appears in both the category listing and README) with its displayed description and link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->