### PR TITLE
Add skill: alessandro-brucato-tracebit/tracebit-canary-honeytokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -1118,6 +1118,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [expanso-tls-inspect](https://clawskills.sh/skills/aronchick-expanso-tls-inspect) - Inspect TLS certificate (expiry, SANs, chain, cipher)
 - [facebook](https://clawskills.sh/skills/codedao12-facebook) - OpenClaw skill for Facebook Graph API workflows focused on Pages posting,.
 - [feelgoodbot](https://clawskills.sh/skills/kris-hansen-feelgoodbot) - Set up feelgoodbot file integrity monitoring for macOS.
+- [tracebit-canary-honeytokens](https://github.com/openclaw/skills/blob/main/skills/alessandro-brucato-tracebit/tracebit-canary-honeytokens/SKILL.md) - Deploy canary honeytokens for data exfiltration detection.
 
 > **[View all 54 skills in Security & Passwords →](categories/security-and-passwords.md)**
 </details>

--- a/README.md
+++ b/README.md
@@ -1118,7 +1118,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [expanso-tls-inspect](https://clawskills.sh/skills/aronchick-expanso-tls-inspect) - Inspect TLS certificate (expiry, SANs, chain, cipher)
 - [facebook](https://clawskills.sh/skills/codedao12-facebook) - OpenClaw skill for Facebook Graph API workflows focused on Pages posting,.
 - [feelgoodbot](https://clawskills.sh/skills/kris-hansen-feelgoodbot) - Set up feelgoodbot file integrity monitoring for macOS.
-- [tracebit-canary-honeytokens](https://github.com/openclaw/skills/blob/main/skills/alessandro-brucato-tracebit/tracebit-canary-honeytokens/SKILL.md) - Deploy canary honeytokens for data exfiltration detection.
+- [tracebit-canary-honeytokens](https://github.com/openclaw/skills/tree/main/skills/alessandro-brucato-tracebit/tracebit-canary-honeytokens) - Deploy canary honeytokens for data exfiltration detection.
 
 > **[View all 54 skills in Security & Passwords →](categories/security-and-passwords.md)**
 </details>


### PR DESCRIPTION
## Summary

Add `alessandro-brucato-tracebit/tracebit-canary-honeytokens` to the Security & Passwords category.

## Skill links

- ClawHub: https://clawhub.ai/alessandro-brucato-tracebit/tracebit-canary-honeytokens
- GitHub: https://github.com/openclaw/skills/tree/main/skills/alessandro-brucato-tracebit/tracebit-canary-honeytokens

## Why this category

This skill helps users deploy and monitor Tracebit canary honeytokens to detect prompt injection, credential theft, and data exfiltration attempts, so Security & Passwords is the closest matching category.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Added a new entry in the Security & Passwords section documenting canary honeytokens for data exfiltration detection, including deployment resources and guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->