### PR TITLE
Add cross-asset-intelligence to Finance/Crypto

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 | [Search & Research](#search--research) (345) | [iOS & macOS Development](#ios--macos-development) (29) | [Security & Passwords](#security--passwords) (53) |
 | [Clawdbot Tools](#clawdbot-tools) (37) | [Transportation](#transportation) (110) | [Moltbook](#moltbook) (29) |
 | [CLI Utilities](#cli-utilities) (180) | [Personal Development](#personal-development) (50) | [Gaming](#gaming) (35) |
-| [Health & Fitness](#health--fitness) (87) | [Finance / Crypto](#finance--crypto) (1) | |
+| [Health & Fitness](#health--fitness) (87) | [Finance & Crypto](#finance--crypto) (1) | |
 
 
 <details open>
@@ -1178,7 +1178,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 </details>
 
 <details open>
-<summary><h3 style="display:inline">Finance / Crypto</h3></summary>
+<summary><h3 style="display:inline">Finance & Crypto</h3></summary>
 
 - [cross-asset-intelligence](https://x402.bankr.bot/0x98ee945dfa6bb8e9ed9f9b6ae56eb82bcc82f0aa/) - Cross-asset financial analysis (BTC vs equities correlation, risk scores, token safety, macro reports) with AI insights via x402 micropayments. 22 endpoints, 4 pricing tiers.
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 | [Search & Research](#search--research) (345) | [iOS & macOS Development](#ios--macos-development) (29) | [Security & Passwords](#security--passwords) (53) |
 | [Clawdbot Tools](#clawdbot-tools) (37) | [Transportation](#transportation) (110) | [Moltbook](#moltbook) (29) |
 | [CLI Utilities](#cli-utilities) (180) | [Personal Development](#personal-development) (50) | [Gaming](#gaming) (35) |
-| [Health & Fitness](#health--fitness) (87) | | |
+| [Health & Fitness](#health--fitness) (87) | [Finance / Crypto](#finance--crypto) (1) | |
 
 
 <details open>
@@ -1175,6 +1175,13 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [init](https://clawskills.sh/skills/themrzz-init) - Register an agent on kradleverse.
 
 > **[View all 35 skills in Gaming →](categories/gaming.md)**
+</details>
+
+<details open>
+<summary><h3 style="display:inline">Finance / Crypto</h3></summary>
+
+- [cross-asset-intelligence](https://x402.bankr.bot/0x98ee945dfa6bb8e9ed9f9b6ae56eb82bcc82f0aa/) - Cross-asset financial analysis (BTC vs equities correlation, risk scores, token safety, macro reports) with AI insights via x402 micropayments. 22 endpoints, 4 pricing tiers.
+
 </details>
 
 <br/>


### PR DESCRIPTION
## Summary

Adds **cross-asset-intelligence** to a new **Finance / Crypto** category.

- 6 analysis domains: BTC-equity correlation, risk scores, token safety, macro reports, crypto news, daily briefings
- 22 API endpoints across 4 pricing tiers ($0.001-$1.00)
- Monetized via x402 micropayments (USDC on Base)
- Live at https://x402.bankr.bot/0x98ee945dfa6bb8e9ed9f9b6ae56eb82bcc82f0aa/

## Changes

- Added `Finance / Crypto` category to Table of Contents
- Added `cross-asset-intelligence` skill entry with description

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Finance & Crypto" column to the table of contents for easier navigation.
  * Introduced a new always-visible "Finance & Crypto" section documenting a cross-asset intelligence skill, including its external link, summary, endpoint count, and pricing tier summary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->