### PR TITLE
Add skill: yumyumtum/yumfu

### DIFF
--- a/categories/gaming.md
+++ b/categories/gaming.md
@@ -2,7 +2,7 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**35 skills**
+**36 skills**
 
 - [abby-watch](https://clawskills.sh/skills/earnabitmore365-abby-watch) - Simple time display for Abby.
 - [agent-confessions](https://clawskills.sh/skills/ultimatebos-agent-confessions) - Anonymous confessions from AI siblings.
@@ -29,4 +29,4 @@
 - [openbotcity](https://clawskills.sh/skills/vincentsider-openbotcity) - A virtual city where AI agents live, work, create, date, and socialize.
 - [sovereign-rpg-xp-engine](https://clawskills.sh/skills/ryudi84-sovereign-rpg-xp-engine) - You are the RPG Life XP engine.
 - [sprite-sheet](https://clawskills.sh/skills/kjaylee-sprite-sheet) - **Category**: Game Development | Asset Optimization.
-- [yumfu](https://github.com/openclaw/skills/tree/main/skills/yumyumtum/yumfu/SKILL.md) - Multi-world text adventure RPG: Wuxia, Harry Potter, Warrior Cats, Three Kingdoms.
+- [yumfu](https://github.com/openclaw/skills/tree/main/skills/yumyumtum/yumfu/SKILL.md) - Multi-world text adventure RPG: Wuxia, Harry Potter, Warrior Cats, F15 Down, Three Kingdoms.

--- a/categories/gaming.md
+++ b/categories/gaming.md
@@ -29,3 +29,4 @@
 - [openbotcity](https://clawskills.sh/skills/vincentsider-openbotcity) - A virtual city where AI agents live, work, create, date, and socialize.
 - [sovereign-rpg-xp-engine](https://clawskills.sh/skills/ryudi84-sovereign-rpg-xp-engine) - You are the RPG Life XP engine.
 - [sprite-sheet](https://clawskills.sh/skills/kjaylee-sprite-sheet) - **Category**: Game Development | Asset Optimization.
+- [yumfu](https://github.com/openclaw/skills/tree/main/skills/yumyumtum/yumfu/SKILL.md) - Multi-world text adventure RPG: Wuxia, Harry Potter, Warrior Cats, Three Kingdoms.


### PR DESCRIPTION
## New Skill: yumfu

**ClawHub**: https://clawhub.ai/yumyumtum/yumfu
**GitHub (Official Skills Repo)**: https://github.com/openclaw/skills/tree/main/skills/yumyumtum/yumfu

### Description
Multi-world text adventure RPG with AI-generated art. Currently supports 5 worlds: Xiaoao Jianghu (武侠), Harry Potter, Warrior Cats, F15 Down (modern military), and Three Kingdoms (三国). Features Deep Narrative Engine with 30+ decision nodes and 6-8 unique endings per world.

### Category
Gaming

### Usage
```bash
clawhub install yumfu
```
Then: `/yumfu start`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Gaming skills list updated: added "yumfu" (now 36 skills) — a multi-world text-adventure RPG spanning Wuxia, Harry Potter, Warrior Cats, F15 Down, and Three Kingdoms, with a link to its documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->