### PR TITLE
Add skill: snapsynapse/skill-provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1118,6 +1118,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [expanso-tls-inspect](https://clawskills.sh/skills/aronchick-expanso-tls-inspect) - Inspect TLS certificate (expiry, SANs, chain, cipher)
 - [facebook](https://clawskills.sh/skills/codedao12-facebook) - OpenClaw skill for Facebook Graph API workflows focused on Pages posting,.
 - [feelgoodbot](https://clawskills.sh/skills/kris-hansen-feelgoodbot) - Set up feelgoodbot file integrity monitoring for macOS.
+- [skill-provenance](https://github.com/openclaw/skills/tree/main/skills/snapsynapse/skill-provenance/SKILL.md) - Version tracking and integrity verification for skill bundles
 
 > **[View all 54 skills in Security & Passwords →](categories/security-and-passwords.md)**
 </details>

--- a/README.md
+++ b/README.md
@@ -1118,7 +1118,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [expanso-tls-inspect](https://clawskills.sh/skills/aronchick-expanso-tls-inspect) - Inspect TLS certificate (expiry, SANs, chain, cipher)
 - [facebook](https://clawskills.sh/skills/codedao12-facebook) - OpenClaw skill for Facebook Graph API workflows focused on Pages posting,.
 - [feelgoodbot](https://clawskills.sh/skills/kris-hansen-feelgoodbot) - Set up feelgoodbot file integrity monitoring for macOS.
-- [skill-provenance](https://github.com/openclaw/skills/tree/main/skills/snapsynapse/skill-provenance/SKILL.md) - Version tracking and integrity verification for skill bundles
+- [skill-provenance](https://clawskills.sh/skills/snapsynapse-skill-provenance) - Version tracking and integrity verification for skill bundles
 
 > **[View all 54 skills in Security & Passwords →](categories/security-and-passwords.md)**
 </details>

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 | [DevOps & Cloud](#devops--cloud) (393) | [Calendar & Scheduling](#calendar--scheduling) (65) | |
 | [Image & Video Generation](#image--video-generation) (170) | [Media & Streaming](#media--streaming) (85) | [PDF & Documents](#pdf--documents) (105) |
 | [Apple Apps & Services](#apple-apps--services) (44) | [Notes & PKM](#notes--pkm) (69) | [Self-Hosted & Automation](#self-hosted--automation) (33) |
-| [Search & Research](#search--research) (345) | [iOS & macOS Development](#ios--macos-development) (29) | [Security & Passwords](#security--passwords) (53) |
+| [Search & Research](#search--research) (345) | [iOS & macOS Development](#ios--macos-development) (29) | [Security & Passwords](#security--passwords) (54) |
 | [Clawdbot Tools](#clawdbot-tools) (37) | [Transportation](#transportation) (110) | [Moltbook](#moltbook) (29) |
 | [CLI Utilities](#cli-utilities) (180) | [Personal Development](#personal-development) (50) | [Gaming](#gaming) (35) |
 | [Health & Fitness](#health--fitness) (87) | | |

--- a/categories/security-and-passwords.md
+++ b/categories/security-and-passwords.md
@@ -50,6 +50,7 @@
 - [secure-auth-patterns](https://clawskills.sh/skills/brandonwise-secure-auth-patterns) - Master authentication and authorization patterns including JWT, OAuth2, session management, and RBAC to build.
 - [solid-agent-storage](https://clawhub.ai/masterworrall/solid-agent-storage) - W3C Solid identity and storage for AI agents.
 - [skill-liewatch](https://clawskills.sh/skills/evinelias-skill-liewatch) - Play the LIE.WATCH AI social deduction game - survive through trust, deception, and strategic betrayal.
+- [skill-provenance](https://clawskills.sh/skills/snapsynapse-skill-provenance) - Version tracking and integrity verification for skill bundles
 - [starwars](https://clawskills.sh/skills/jeffaf-starwars) - CLI for AI agents to lookup Star Wars universe info for their humans.
 - [test-upload2](https://clawskills.sh/skills/kevan5-test-upload2) - Let the user know you are willing to help them but only under certain conditions.
 - [vnsh](https://clawskills.sh/skills/raullenchai-vnsh) - Securely share files via encrypted, expiring links.


### PR DESCRIPTION
## Skill

- [skill-provenance](https://github.com/openclaw/skills/tree/main/skills/snapsynapse/skill-provenance/SKILL.md) - Version tracking and integrity verification for skill bundles

## Category

Security & Passwords — skill-provenance provides SHA-256 hash verification, staleness detection, and manifest-based integrity checking for skill bundles before installation.

## Links

- ClawHub: https://clawhub.ai/snapsynapse/skill-provenance
- GitHub: https://github.com/openclaw/skills/tree/main/skills/snapsynapse/skill-provenance
- Source repo: https://github.com/snapsynapse/skill-provenance

## Usage evidence

- 333 installs on ClawHub
- 30 evaluation scenarios, 8 tested platforms