### PR TITLE
Add skill: trent-ai-release/trentclaw

### DIFF
--- a/README.md
+++ b/README.md
@@ -1085,7 +1085,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [pinme](https://clawskills.sh/skills/ntlx-pinme) - Deploy static websites to IPFS with a single command using PinMe CLI.
 - [sonarqube-analyzer](https://clawskills.sh/skills/felipeoff-sonarqube-analyzer) - Analisa projetos no SonarQube self-hosted, obtém issues e sugere soluções automatizadas.
 - [system-integrity-and-backup](https://clawskills.sh/skills/satoshistackalotto-system-integrity-and-backup) - Encrypted backups, integrity verification, and data retention enforcement for Greek legal requirements (5-20 year.
-
+- [trent-openclaw-security-assessment](https://github.com/openclaw/skills/blob/main/skills/trent-ai-release/trentclaw/SKILL.md) - Identify misconfigurations, chained attack paths, and get severity-rated findings with fixes. Powered by the Trent AI API.
 > **[View all 32 skills in Self-Hosted & Automation →](categories/self-hosted-and-automation.md)**
 </details>
 
@@ -1118,6 +1118,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [expanso-tls-inspect](https://clawskills.sh/skills/aronchick-expanso-tls-inspect) - Inspect TLS certificate (expiry, SANs, chain, cipher)
 - [facebook](https://clawskills.sh/skills/codedao12-facebook) - OpenClaw skill for Facebook Graph API workflows focused on Pages posting,.
 - [feelgoodbot](https://clawskills.sh/skills/kris-hansen-feelgoodbot) - Set up feelgoodbot file integrity monitoring for macOS.
+- 
 
 > **[View all 54 skills in Security & Passwords →](categories/security-and-passwords.md)**
 </details>

--- a/README.md
+++ b/README.md
@@ -1118,7 +1118,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [expanso-tls-inspect](https://clawskills.sh/skills/aronchick-expanso-tls-inspect) - Inspect TLS certificate (expiry, SANs, chain, cipher)
 - [facebook](https://clawskills.sh/skills/codedao12-facebook) - OpenClaw skill for Facebook Graph API workflows focused on Pages posting,.
 - [feelgoodbot](https://clawskills.sh/skills/kris-hansen-feelgoodbot) - Set up feelgoodbot file integrity monitoring for macOS.
-- [trentclaw](https://clawhub.ai/trent-ai-release/trentclaw) - OpenClaw security assesment skill. Identify misconfigurations, chained attack paths, and get severity-rated findings with fixes.
+- [trentclaw](https://clawhub.ai/trent-ai-release/trentclaw) - Identify misconfigurations, chained attack paths, and get severity-rated findings with remediations.
 
 > **[View all 54 skills in Security & Passwords →](categories/security-and-passwords.md)**
 </details>

--- a/README.md
+++ b/README.md
@@ -1085,7 +1085,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [pinme](https://clawskills.sh/skills/ntlx-pinme) - Deploy static websites to IPFS with a single command using PinMe CLI.
 - [sonarqube-analyzer](https://clawskills.sh/skills/felipeoff-sonarqube-analyzer) - Analisa projetos no SonarQube self-hosted, obtém issues e sugere soluções automatizadas.
 - [system-integrity-and-backup](https://clawskills.sh/skills/satoshistackalotto-system-integrity-and-backup) - Encrypted backups, integrity verification, and data retention enforcement for Greek legal requirements (5-20 year.
-- [trent-openclaw-security-assessment](https://github.com/openclaw/skills/blob/main/skills/trent-ai-release/trentclaw/SKILL.md) - Identify misconfigurations, chained attack paths, and get severity-rated findings with fixes. Powered by the Trent AI API.
+
 > **[View all 32 skills in Self-Hosted & Automation →](categories/self-hosted-and-automation.md)**
 </details>
 
@@ -1118,7 +1118,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [expanso-tls-inspect](https://clawskills.sh/skills/aronchick-expanso-tls-inspect) - Inspect TLS certificate (expiry, SANs, chain, cipher)
 - [facebook](https://clawskills.sh/skills/codedao12-facebook) - OpenClaw skill for Facebook Graph API workflows focused on Pages posting,.
 - [feelgoodbot](https://clawskills.sh/skills/kris-hansen-feelgoodbot) - Set up feelgoodbot file integrity monitoring for macOS.
-- 
+- [trentclaw](https://clawhub.ai/trent-ai-release/trentclaw) - OpenClaw security assesment skill. Identify misconfigurations, chained attack paths, and get severity-rated findings with fixes.
 
 > **[View all 54 skills in Security & Passwords →](categories/security-and-passwords.md)**
 </details>


### PR DESCRIPTION
Added new skill trent-ai-rlease/trentclaw to the awesome-openclaw-skills list.

- https://clawhub.ai/trent-ai-release/trentclaw
- https://github.com/openclaw/skills/tree/main/skills/trent-ai-release/trentclaw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Security & Passwords entry for the "trentclaw" skill linking to ClawHub, describing misconfiguration detection, chained attack-path analysis, and severity-rated findings with remediation guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->