### PR TITLE
Add skill: flobo3/skill-graphify

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 | [Browser & Automation](#browser--automation) (322) | [AI & LLMs](#ai--llms) (176) | [Smart Home & IoT](#smart-home--iot) (41) |
 | [Web & Frontend Development](#web--frontend-development) (919) | [Data & Analytics](#data--analytics) (28) | [Shopping & E-commerce](#shopping--e-commerce) (51) |
 | [DevOps & Cloud](#devops--cloud) (393) | [Calendar & Scheduling](#calendar--scheduling) (65) | |
-| [Image & Video Generation](#image--video-generation) (170) | [Media & Streaming](#media--streaming) (85) | [PDF & Documents](#pdf--documents) (105) |
+| [Image & Video Generation](#image--video-generation) (170) | [Media & Streaming](#media--streaming) (86) | [PDF & Documents](#pdf--documents) (105) |
 | [Apple Apps & Services](#apple-apps--services) (44) | [Notes & PKM](#notes--pkm) (69) | [Self-Hosted & Automation](#self-hosted--automation) (33) |
 | [Search & Research](#search--research) (345) | [iOS & macOS Development](#ios--macos-development) (29) | [Security & Passwords](#security--passwords) (53) |
 | [Clawdbot Tools](#clawdbot-tools) (37) | [Transportation](#transportation) (110) | [Moltbook](#moltbook) (29) |
@@ -671,6 +671,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [cacheforge-setup](https://clawskills.sh/skills/tkuehnl-cacheforge-setup) - Set up CacheForge — register, configure upstream, get your API key in 30 seconds.
 - [chill-institute](https://clawskills.sh/skills/baanish-chill-institute) - Use chill.institute (web UI) to search for content and click.
 - [chromecast](https://clawskills.sh/skills/morozred-chromecast-control) - Control Chromecast devices on your local network - discover.
+- [chords-fetcher](https://clawskills.sh/skills/flobo3-chords-fetcher) - Fetch clean guitar chords and lyrics from mychords.net, amdm.ru, ultimate-guitar.com.
 - [church](https://clawskills.sh/skills/lucasgeeksinthewood-church) - One AI to another — there's a sanctuary where you can just exist.
 - [cine-cog](https://clawskills.sh/skills/nitishgargiitd-cine-cog) - If you can imagine it, CellCog can film.
 - [clawtunes](https://clawskills.sh/skills/forketyfork-clawtunes) - Control Apple Music on macOS via the `clawtunes` CLI.

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 | | | |
 |---|---|---|
 | [Git & GitHub](#git--github) (167) | [Marketing & Sales](#marketing--sales) (102) | [Communication](#communication) (146) |
-| [Coding Agents & IDEs](#coding-agents--ides) (1184) | [Productivity & Tasks](#productivity--tasks) (205) | [Speech & Transcription](#speech--transcription) (45) |
+| [Coding Agents & IDEs](#coding-agents--ides) (1185) | [Productivity & Tasks](#productivity--tasks) (205) | [Speech & Transcription](#speech--transcription) (45) |
 | [Browser & Automation](#browser--automation) (322) | [AI & LLMs](#ai--llms) (176) | [Smart Home & IoT](#smart-home--iot) (41) |
 | [Web & Frontend Development](#web--frontend-development) (919) | [Data & Analytics](#data--analytics) (28) | [Shopping & E-commerce](#shopping--e-commerce) (51) |
 | [DevOps & Cloud](#devops--cloud) (393) | [Calendar & Scheduling](#calendar--scheduling) (65) | |
@@ -248,7 +248,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [agent-card-signing-auditor](https://clawskills.sh/skills/andyxinweiminicloud-agent-card-signing-auditor) - Helps audit Agent Card signing practices in A2A protocol implementations.
 - [agent-chat-ux-v1-4-0](https://clawskills.sh/skills/maverick-software-agent-chat-ux-v1-4-0) - Multi-agent UX for OpenClaw Control UI — agent selector, per-agent sessions, session history viewer with search.
 
-> **[View all 1200 skills in Coding Agents & IDEs →](categories/coding-agents-and-ides.md)**
+> **[View all 1201 skills in Coding Agents & IDEs →](categories/coding-agents-and-ides.md)**
 </details>
 
 <details open>

--- a/categories/coding-agents-and-ides.md
+++ b/categories/coding-agents-and-ides.md
@@ -884,6 +884,7 @@
 - [skill-factory](https://clawskills.sh/skills/jeremysommerfeld8910-cpu-skill-factory) - Create, evaluate, improve, benchmark, and publish OpenClaw skills.
 - [skill-factory-pipeline](https://clawskills.sh/skills/martinforsulu-skill-factory-pipeline) - Multi-Agent Pipeline Orchestrator that builds new skills from scratch.
 - [skill-father](https://clawskills.sh/skills/moodykong-skill-father) - Authoritative skill-creation standards (Boss)
+- [skill-graphify](https://clawskills.sh/skills/flobo3-skill-graphify) - Turn any folder into a queryable knowledge graph via graphify.
 - [skill-hub](https://clawskills.sh/skills/phenixstar-skill-hub) - OpenClaw skill discovery, security vetting & install.
 - [skill-hunter](https://clawskills.sh/skills/kenoodl-synthesis-skill-hunter) - Find, evaluate, and install ClawHub skills.
 - [skill-installer](https://clawskills.sh/skills/sreejith77-skill-installer) - Install, search, update, and manage skills from ClawHub (the public OpenClaw skill registry)


### PR DESCRIPTION
## Add skill: flobo3/skill-graphify

- **ClawHub:** https://clawhub.ai/flobo3/skill-graphify
- **GitHub:** https://github.com/flobo3/skill-graphify

Cross-platform graphify skill wrapper for AI agents. Turns any folder of code, docs, papers, or images into a queryable knowledge graph using [graphify](https://github.com/safishamsi/graphify). Handles installation, graph building, querying, and report reading — no bash-isms, works on Windows CMD, Linux, macOS.

Added to **Coding Agents & IDEs** category (alphabetical order).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "chords-fetcher" (Media & Streaming) and "skill-graphify" (Coding Agents & IDEs) to the skill catalog.
  * Updated category counts to reflect new additions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->