### PR TITLE
Add Zero Human Skills (business automation)

### DIFF
--- a/categories/marketing-and-sales.md
+++ b/categories/marketing-and-sales.md
@@ -2,7 +2,7 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**103 skills**
+**106 skills**
 
 - [4chan-reader](https://clawskills.sh/skills/aiasisbot61-4chan-reader) - Browse 4chan boards and extract thread discussions.
 - [ad-ready](https://clawskills.sh/skills/pauldelavallaz-ad-ready) - Generate professional advertising images from product URLs.
@@ -103,4 +103,4 @@
 - [writing-group-leader](https://clawskills.sh/skills/urrrich-writing-group-leader) - You are a Writing Team Lead managing specialized writers via MCP tools.
 - [zero-human-audit](https://github.com/iwearyourshirt/zero-human-skills/tree/main/zero-human-audit) - Run a structured automation audit on any business. Scores each function for AI potential, recommends specific tools with real pricing, maps automation workflows, and builds a phased roadmap with ROI math.
 - [ai-stack-builder](https://github.com/iwearyourshirt/zero-human-skills/tree/main/ai-stack-builder) - Build a complete AI tool stack for any business type and budget. Decision trees, integration flows, and day-by-day setup plans for solopreneur, SaaS, e-commerce, agency, and local businesses.
-- [zero-human-content-engine](https://github.com/iwearyourshirt/zero-human-skills/tree/main/zero-human-content-engine) - Set up autonomous content publishing with topic discovery, AI writing, SEO optimization, and GitHub Actions deployment. Runs a daily blog for $5-15/month.
+- [zero-human-content-engine](https://github.com/iwearyourshirt/zero-human-skills/tree/main/zero-human-content-engine) - Set up autonomous content publishing with topic discovery, AI writing, SEO, and GitHub Actions deployment. Runs a daily blog for $5-15/month.

--- a/categories/marketing-and-sales.md
+++ b/categories/marketing-and-sales.md
@@ -101,3 +101,6 @@
 - [workcrm](https://clawskills.sh/skills/extraterrest-workcrm) - A lightweight, local-first CRM with an explicit confirmation gate.
 - [writing-assistant](https://clawskills.sh/skills/urrrich-writing-assistant) - You are a Writing Team Lead managing specialized writers via MCP tools.
 - [writing-group-leader](https://clawskills.sh/skills/urrrich-writing-group-leader) - You are a Writing Team Lead managing specialized writers via MCP tools.
+- [zero-human-audit](https://github.com/iwearyourshirt/zero-human-skills/tree/main/zero-human-audit) - Run a structured automation audit on any business. Scores each function for AI potential, recommends specific tools with real pricing, maps automation workflows, and builds a phased roadmap with ROI math.
+- [ai-stack-builder](https://github.com/iwearyourshirt/zero-human-skills/tree/main/ai-stack-builder) - Build a complete AI tool stack for any business type and budget. Decision trees, integration flows, and day-by-day setup plans for solopreneur, SaaS, e-commerce, agency, and local businesses.
+- [zero-human-content-engine](https://github.com/iwearyourshirt/zero-human-skills/tree/main/zero-human-content-engine) - Set up autonomous content publishing with topic discovery, AI writing, SEO optimization, and GitHub Actions deployment. Runs a daily blog for $5-15/month.


### PR DESCRIPTION
## 3 new skills for the Marketing & Sales category

**zero-human-audit** - Structured automation audit for any business. Walks through every department, scores automation potential, recommends specific tools with real monthly pricing, maps out workflows step-by-step, and builds a phased implementation roadmap with ROI calculations.

**ai-stack-builder** - Builds complete AI tool stacks by business type (solopreneur, SaaS, e-commerce, agency, local service). Includes decision trees for choosing between tools, integration flow diagrams, red flags to watch for, and day-by-day setup sequences.

**zero-human-content-engine** - Autonomous content publishing system using GitHub Actions, Claude/GPT APIs, and static site deployment. Topic discovery from Reddit/HN, voice matching, SEO optimization. Runs a daily blog for $5-15/month.

All three are open source (MIT-0), hosted at https://github.com/iwearyourshirt/zero-human-skills

Built by Jason Zook (zerohumanplaybook.com).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated marketing-and-sales skills list: total count changed from 103 to 106.
  * Added three new entries — zero-human-audit, ai-stack-builder, zero-human-content-engine — each with descriptive text and links for discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->