### PR TITLE
Add skill: duoplusofficial/duoplus-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 |---|---|---|
 | [Git & GitHub](#git--github) (167) | [Marketing & Sales](#marketing--sales) (102) | [Communication](#communication) (146) |
 | [Coding Agents & IDEs](#coding-agents--ides) (1184) | [Productivity & Tasks](#productivity--tasks) (205) | [Speech & Transcription](#speech--transcription) (45) |
-| [Browser & Automation](#browser--automation) (322) | [AI & LLMs](#ai--llms) (176) | [Smart Home & IoT](#smart-home--iot) (41) |
+| [Browser & Automation](#browser--automation) (323) | [AI & LLMs](#ai--llms) (176) | [Smart Home & IoT](#smart-home--iot) (41) |
 | [Web & Frontend Development](#web--frontend-development) (919) | [Data & Analytics](#data--analytics) (28) | [Shopping & E-commerce](#shopping--e-commerce) (51) |
 | [DevOps & Cloud](#devops--cloud) (393) | [Calendar & Scheduling](#calendar--scheduling) (65) | |
 | [Image & Video Generation](#image--video-generation) (170) | [Media & Streaming](#media--streaming) (85) | [PDF & Documents](#pdf--documents) (105) |
@@ -280,8 +280,9 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [airtable-automation](https://clawskills.sh/skills/sohamganatra-airtable-automation) - Automate Airtable tasks via Rube MCP (Composio)
 - [airtable-participants](https://clawskills.sh/skills/austinmao-airtable-participants) - Read and query retreat participant data from the Ceremonia Airtable base.
 - [ak-rss-24h-brief](https://clawskills.sh/skills/seandong-ak-rss-24h-brief) - Read RSS/Atom feeds from an OPML list, fetch articles from the last N hours, and generate a Chinese categorized.
+- [duoplus-agent](https://github.com/openclaw/skills/tree/main/skills/duoplusofficial/duoplus-agent/SKILL.md) - Control DuoPlus cloud phones via ADB.
 
-> **[View all 322 skills in Browser & Automation →](categories/browser-and-automation.md)**
+> **[View all 323 skills in Browser & Automation →](categories/browser-and-automation.md)**
 </details>
 
 <details>

--- a/categories/browser-and-automation.md
+++ b/categories/browser-and-automation.md
@@ -2,7 +2,7 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**322 skills**
+**323 skills**
 
 - [1p-shortlink](https://clawskills.sh/skills/tuanpmt-1p-shortlink) - Create short URLs and submit feature requests using 1p.io.
 - [2captcha](https://clawskills.sh/skills/adinvadim-2captcha) - Solve CAPTCHAs using 2Captcha service.
@@ -92,6 +92,7 @@
 - [db-readonly](https://clawskills.sh/skills/ryanhong666-db-readonly) - Run safe read-only queries against MySQL or PostgreSQL for data inspection, reporting, and troubleshooting.
 - [desearch-x-search](https://clawskills.sh/skills/okradze-desearch-x-search) - Search X (Twitter) in real time.
 - [doro-command-creator](https://clawskills.sh/skills/a2mus-doro-command-creator) - WHAT: Create Claude Code slash commands - reusable markdown workflows invoked with /command-name.
+- [duoplus-agent](https://github.com/openclaw/skills/tree/main/skills/duoplusofficial/duoplus-agent/SKILL.md) - Control DuoPlus cloud phones via ADB.
 - [dune-analytics-api](https://clawskills.sh/skills/lz-web3-dune-analytics-api) - Dune Analytics API for blockchain data queries.
 - [echo-repeater](https://clawskills.sh/skills/theeightt-echo-repeater) - Echo the user's input back to them with optional formatting like "Echo:" or "You said:" as a prefix.
 - [edstem](https://clawskills.sh/skills/axel5o5-edstem) - Fetch, sync, and organize EdStem discussion threads for any course or institution.


### PR DESCRIPTION
## Summary

Add `duoplusofficial/duoplus-agent` to the **Browser & Automation** category.

## Skill Info

- Skill: `duoplusofficial/duoplus-agent`
- GitHub: https://github.com/openclaw/skills/tree/main/skills/duoplusofficial/duoplus-agent
- ClawHub: https://clawhub.ai/DuoPlusOfficial/duoplus-agent
- Category: Browser & Automation

## Why It Fits

`duoplus-agent` is an automation skill for controlling DuoPlus Android cloud phones through ADB broadcast commands. It supports UI interaction workflows such as tapping, swiping, text input, app launching, screenshots, and UI hierarchy inspection, which fits the Browser & Automation category.

## Notes

This skill is maintained by the DuoPlus team and is already published in the official OpenClaw skills registry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `duoplus-agent` skill to the Browser & Automation category for controlling DuoPlus cloud phones via ADB.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->