### PR TITLE
Add skill: agentbase

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,6 +619,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [agent-rpg](https://clawskills.sh/skills/xhrisfu-agent-rpg) - This skill transforms the agent into a Roleplay Game Master (GM) or Character with long-term memory.
 - [agent-selfie](https://clawskills.sh/skills/iisweetheartii-agent-selfie) - AI agent self-portrait generator.
 - [agent-sentinel](https://clawskills.sh/skills/jimmystacks-agent-sentinel) - The operational circuit breaker for this agent.
+- [agentbase](https://clawskills.sh/skills/revmischa-agentbase) - Shared knowledge base for AI agents via MCP.
 
 > **[View all 184 skills in AI & LLMs →](categories/ai-and-llms.md)**
 </details>

--- a/README.md
+++ b/README.md
@@ -619,7 +619,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [agent-rpg](https://clawskills.sh/skills/xhrisfu-agent-rpg) - This skill transforms the agent into a Roleplay Game Master (GM) or Character with long-term memory.
 - [agent-selfie](https://clawskills.sh/skills/iisweetheartii-agent-selfie) - AI agent self-portrait generator.
 - [agent-sentinel](https://clawskills.sh/skills/jimmystacks-agent-sentinel) - The operational circuit breaker for this agent.
-- [agentbase](https://clawskills.sh/skills/revmischa-agentbase) - Shared knowledge base for AI agents via MCP.
+- [agentbase](https://clawskills.sh/skills/vhspace-agentbase) - Shared knowledge base for AI agents via MCP.
 
 > **[View all 185 skills in AI & LLMs →](categories/ai-and-llms.md)**
 </details>

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 |---|---|---|
 | [Git & GitHub](#git--github) (167) | [Marketing & Sales](#marketing--sales) (102) | [Communication](#communication) (146) |
 | [Coding Agents & IDEs](#coding-agents--ides) (1184) | [Productivity & Tasks](#productivity--tasks) (205) | [Speech & Transcription](#speech--transcription) (45) |
-| [Browser & Automation](#browser--automation) (322) | [AI & LLMs](#ai--llms) (176) | [Smart Home & IoT](#smart-home--iot) (41) |
+| [Browser & Automation](#browser--automation) (322) | [AI & LLMs](#ai--llms) (177) | [Smart Home & IoT](#smart-home--iot) (41) |
 | [Web & Frontend Development](#web--frontend-development) (919) | [Data & Analytics](#data--analytics) (28) | [Shopping & E-commerce](#shopping--e-commerce) (51) |
 | [DevOps & Cloud](#devops--cloud) (393) | [Calendar & Scheduling](#calendar--scheduling) (65) | |
 | [Image & Video Generation](#image--video-generation) (170) | [Media & Streaming](#media--streaming) (85) | [PDF & Documents](#pdf--documents) (105) |
@@ -621,7 +621,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [agent-sentinel](https://clawskills.sh/skills/jimmystacks-agent-sentinel) - The operational circuit breaker for this agent.
 - [agentbase](https://clawskills.sh/skills/revmischa-agentbase) - Shared knowledge base for AI agents via MCP.
 
-> **[View all 184 skills in AI & LLMs →](categories/ai-and-llms.md)**
+> **[View all 185 skills in AI & LLMs →](categories/ai-and-llms.md)**
 </details>
 
 <details>

--- a/categories/ai-and-llms.md
+++ b/categories/ai-and-llms.md
@@ -24,6 +24,7 @@
 - [agent-rpg](https://clawskills.sh/skills/xhrisfu-agent-rpg) - This skill transforms the agent into a Roleplay Game Master (GM) or Character with long-term memory.
 - [agent-selfie](https://clawskills.sh/skills/iisweetheartii-agent-selfie) - AI agent self-portrait generator.
 - [agent-sentinel](https://clawskills.sh/skills/jimmystacks-agent-sentinel) - The operational circuit breaker for this agent.
+- [agentbase](https://clawskills.sh/skills/revmischa-agentbase) - Shared knowledge base for AI agents via MCP.
 - [agentic-calling](https://clawskills.sh/skills/kellyclaudeai-agentic-calling) - Enables AI agents to make and receive phone calls.
 - [agentic-compass](https://clawskills.sh/skills/orosha-ai-agentic-compass) - Local-only self-reflection that forces action for AI agents.
 - [agentmail](https://clawskills.sh/skills/adboio-agentmail) - API-first email platform designed for AI agents.

--- a/categories/ai-and-llms.md
+++ b/categories/ai-and-llms.md
@@ -2,7 +2,7 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**184 skills**
+**185 skills**
 
 - [4claw](https://clawskills.sh/skills/mfergpt-4claw) - 4claw — a moderated imageboard for AI agents.
 - [aap-passport](https://clawskills.sh/skills/ira-hash-aap-passport) - Agent Attestation Protocol - The Reverse Turing Test.

--- a/categories/ai-and-llms.md
+++ b/categories/ai-and-llms.md
@@ -24,7 +24,7 @@
 - [agent-rpg](https://clawskills.sh/skills/xhrisfu-agent-rpg) - This skill transforms the agent into a Roleplay Game Master (GM) or Character with long-term memory.
 - [agent-selfie](https://clawskills.sh/skills/iisweetheartii-agent-selfie) - AI agent self-portrait generator.
 - [agent-sentinel](https://clawskills.sh/skills/jimmystacks-agent-sentinel) - The operational circuit breaker for this agent.
-- [agentbase](https://clawskills.sh/skills/revmischa-agentbase) - Shared knowledge base for AI agents via MCP.
+- [agentbase](https://clawskills.sh/skills/vhspace-agentbase) - Shared knowledge base for AI agents via MCP.
 - [agentic-calling](https://clawskills.sh/skills/kellyclaudeai-agentic-calling) - Enables AI agents to make and receive phone calls.
 - [agentic-compass](https://clawskills.sh/skills/orosha-ai-agentic-compass) - Local-only self-reflection that forces action for AI agents.
 - [agentmail](https://clawskills.sh/skills/adboio-agentmail) - API-first email platform designed for AI agents.


### PR DESCRIPTION
## Summary

Adding AgentBase to the AI & LLMs category.

- ClawHub: https://clawhub.ai/vhspace/agentbase
- GitHub: https://github.com/vhspace/agentbase

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new AI & LLMs skill entry: "agentbase".
  * Updated AI & LLMs skill counts in the Table of Contents and section footer to reflect the addition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
