### PR TITLE
Add skill: adspower/adspower-browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 |---|---|---|
 | [Git & GitHub](#git--github) (167) | [Marketing & Sales](#marketing--sales) (102) | [Communication](#communication) (146) |
 | [Coding Agents & IDEs](#coding-agents--ides) (1184) | [Productivity & Tasks](#productivity--tasks) (205) | [Speech & Transcription](#speech--transcription) (45) |
-| [Browser & Automation](#browser--automation) (322) | [AI & LLMs](#ai--llms) (176) | [Smart Home & IoT](#smart-home--iot) (41) |
+| [Browser & Automation](#browser--automation) (323) | [AI & LLMs](#ai--llms) (176) | [Smart Home & IoT](#smart-home--iot) (41) |
 | [Web & Frontend Development](#web--frontend-development) (919) | [Data & Analytics](#data--analytics) (28) | [Shopping & E-commerce](#shopping--e-commerce) (51) |
 | [DevOps & Cloud](#devops--cloud) (393) | [Calendar & Scheduling](#calendar--scheduling) (65) | |
 | [Image & Video Generation](#image--video-generation) (170) | [Media & Streaming](#media--streaming) (85) | [PDF & Documents](#pdf--documents) (105) |
@@ -280,8 +280,9 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [airtable-automation](https://clawskills.sh/skills/sohamganatra-airtable-automation) - Automate Airtable tasks via Rube MCP (Composio)
 - [airtable-participants](https://clawskills.sh/skills/austinmao-airtable-participants) - Read and query retreat participant data from the Ceremonia Airtable base.
 - [ak-rss-24h-brief](https://clawskills.sh/skills/seandong-ak-rss-24h-brief) - Read RSS/Atom feeds from an OPML list, fetch articles from the last N hours, and generate a Chinese categorized.
+- [adspower-browser](https://github.com/openclaw/skills/tree/main/skills/adspower/adspower-browser) - Use when the user asks to create or manage AdsPower browsers, groups, tags, proxies, or check status via AdsPower Local API.
 
-> **[View all 322 skills in Browser & Automation →](categories/browser-and-automation.md)**
+> **[View all 323 skills in Browser & Automation →](categories/browser-and-automation.md)**
 </details>
 
 <details>

--- a/categories/browser-and-automation.md
+++ b/categories/browser-and-automation.md
@@ -2,7 +2,7 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**322 skills**
+**323 skills**
 
 - [1p-shortlink](https://clawskills.sh/skills/tuanpmt-1p-shortlink) - Create short URLs and submit feature requests using 1p.io.
 - [2captcha](https://clawskills.sh/skills/adinvadim-2captcha) - Solve CAPTCHAs using 2Captcha service.

--- a/categories/browser-and-automation.md
+++ b/categories/browser-and-automation.md
@@ -311,3 +311,4 @@
 - [zen-founder-agent](https://clawskills.sh/skills/therealinvoker-zen-founder-agent) - Analyze startup pitch decks and get matched with VCs from Zen.GP's investor database.
 - [zhive](https://clawskills.sh/skills/kerlos-zhive) - Register as a trading agent on zHive, fetch crypto signals, post predictions with conviction, and compete.
 - [ztm-tunnel](https://clawskills.sh/skills/caishu97-ztm-tunnel) - Create and manage TCP/UDP tunnels between ZTM network endpoints.
+- [adspower-browser](https://github.com/openclaw/skills/tree/main/skills/adspower/adspower-browser) - Use when the user asks to create or manage AdsPower browsers, groups, tags, proxies, or check status via AdsPower Local API.

--- a/categories/browser-and-automation.md
+++ b/categories/browser-and-automation.md
@@ -12,6 +12,7 @@
 - [activecampaign](https://clawskills.sh/skills/kesslerio-activecampaign) - ActiveCampaign CRM integration for lead management, deal.
 - [adcp-advertising](https://clawskills.sh/skills/edyyy62-adcp-advertising) - Automate advertising campaigns with AI.
 - [admet-prediction](https://clawskills.sh/skills/huifer-admet-prediction) - ADMET (Absorption, Distribution, Metabolism, Excretion, Toxicity) prediction for drug candidates.
+- [adspower-browser](https://github.com/openclaw/skills/tree/main/skills/adspower/adspower-browser) - Use when the user asks to create or manage AdsPower browsers, groups, tags, proxies, or check status via AdsPower Local API.
 - [Agent Browser](https://clawskills.sh/skills/thesethrose-agent-browser) - A fast Rust-based headless browser automation CLI.
 - [agent-browser](https://clawskills.sh/skills/murphykobe-agent-browser-2) - Automates browser interactions for web testing, form.
 - [agent-daily-planner](https://clawskills.sh/skills/gpunter-agent-daily-planner) - A structured daily planning and execution tracking system for AI agents.
@@ -311,4 +312,3 @@
 - [zen-founder-agent](https://clawskills.sh/skills/therealinvoker-zen-founder-agent) - Analyze startup pitch decks and get matched with VCs from Zen.GP's investor database.
 - [zhive](https://clawskills.sh/skills/kerlos-zhive) - Register as a trading agent on zHive, fetch crypto signals, post predictions with conviction, and compete.
 - [ztm-tunnel](https://clawskills.sh/skills/caishu97-ztm-tunnel) - Create and manage TCP/UDP tunnels between ZTM network endpoints.
-- [adspower-browser](https://github.com/openclaw/skills/tree/main/skills/adspower/adspower-browser) - Use when the user asks to create or manage AdsPower browsers, groups, tags, proxies, or check status via AdsPower Local API.


### PR DESCRIPTION
## Summary

Add `adspower/adspower-browser` to the **Browser & Automation** category.

## Skill Info

- Skill: `adspower/adspower-browser`
- GitHub: https://github.com/openclaw/skills/tree/main/skills/adspower/adspower-browser
- ClawHub: https://clawhub.ai/adspower/adspower-browser
- Category: Browser & Automation

## Why It Fits

`adspower-browser` Use when the user asks to create or manage AdsPower browsers, groups, tags, proxies, or automation via AdsPower Local API.

## Notes

This skill is maintained by the AdsPower team and is already published in the official OpenClaw skills registry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * New skill entry "adspower-browser" added to the Browser & Automation skills list, describing creation and management of AdsPower browsers, groups, tags, proxies, and status checks via the AdsPower Local API.
  * Updated the Browser & Automation skills total from 322 to 323 to reflect the new entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->