### PR TITLE
Add skill: johnmalek312/mobilerun

### DIFF
--- a/categories/browser-and-automation.md
+++ b/categories/browser-and-automation.md
@@ -179,7 +179,7 @@
 - [mh-notion](https://clawskills.sh/skills/mohdalhashemi98-hue-mh-notion) - Notion API for creating and managing pages, databases, and blocks.
 - [minimal-memory](https://clawskills.sh/skills/zencrust-ai-minimal-memory) - Maintain clean, efficient memory files with GOOD/BAD/NEUTRAL categorization and semantic search.
 - [minimax-speech](https://clawskills.sh/skills/wingchiu-minimax-speech) - Manage MiniMax Speech 2.8 T2A (text-to-audio) and voice catalog lookups.
-- [mobilerun](https://github.com/openclaw/skills/tree/main/skills/johnmalek312/mobilerun/SKILL.md) - Automate Android devices — tap, swipe, type, screenshot. iOS soon.
+- [mobilerun](https://github.com/openclaw/skills/tree/main/skills/johnmalek312/mobilerun/SKILL.md) - Control Android devices: tap, swipe, type, screenshot (iOS coming soon).
 - [mukt](https://clawskills.sh/skills/hgosansn-mukt) - Zero-cost OpenRouter responder that auto-discovers the best currently free model, retries on failures, and returns.
 - [multilogin](https://clawskills.sh/skills/glebkazachinskiy-multilogin) - Use when you need to manage Multilogin X browser profiles — launch quick disposable profiles, list/start/stop saved.
 - [multiloginx](https://clawskills.sh/skills/multilogincom-multiloginx) - Use when you need to manage Multilogin X browser profiles — launch quick disposable profiles, list/start/stop saved.

--- a/categories/browser-and-automation.md
+++ b/categories/browser-and-automation.md
@@ -179,7 +179,7 @@
 - [mh-notion](https://clawskills.sh/skills/mohdalhashemi98-hue-mh-notion) - Notion API for creating and managing pages, databases, and blocks.
 - [minimal-memory](https://clawskills.sh/skills/zencrust-ai-minimal-memory) - Maintain clean, efficient memory files with GOOD/BAD/NEUTRAL categorization and semantic search.
 - [minimax-speech](https://clawskills.sh/skills/wingchiu-minimax-speech) - Manage MiniMax Speech 2.8 T2A (text-to-audio) and voice catalog lookups.
-- [mobilerun](https://github.com/openclaw/skills/tree/main/skills/johnmalek312/mobilerun/SKILL.md) - Control Android phones: tap, swipe, type, screenshot, automate apps.
+- [mobilerun](https://github.com/openclaw/skills/tree/main/skills/johnmalek312/mobilerun/SKILL.md) - Automate Android devices — tap, swipe, type, screenshot. iOS soon.
 - [mukt](https://clawskills.sh/skills/hgosansn-mukt) - Zero-cost OpenRouter responder that auto-discovers the best currently free model, retries on failures, and returns.
 - [multilogin](https://clawskills.sh/skills/glebkazachinskiy-multilogin) - Use when you need to manage Multilogin X browser profiles — launch quick disposable profiles, list/start/stop saved.
 - [multiloginx](https://clawskills.sh/skills/multilogincom-multiloginx) - Use when you need to manage Multilogin X browser profiles — launch quick disposable profiles, list/start/stop saved.

--- a/categories/browser-and-automation.md
+++ b/categories/browser-and-automation.md
@@ -2,7 +2,7 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**322 skills**
+**323 skills**
 
 - [1p-shortlink](https://clawskills.sh/skills/tuanpmt-1p-shortlink) - Create short URLs and submit feature requests using 1p.io.
 - [2captcha](https://clawskills.sh/skills/adinvadim-2captcha) - Solve CAPTCHAs using 2Captcha service.
@@ -179,6 +179,7 @@
 - [mh-notion](https://clawskills.sh/skills/mohdalhashemi98-hue-mh-notion) - Notion API for creating and managing pages, databases, and blocks.
 - [minimal-memory](https://clawskills.sh/skills/zencrust-ai-minimal-memory) - Maintain clean, efficient memory files with GOOD/BAD/NEUTRAL categorization and semantic search.
 - [minimax-speech](https://clawskills.sh/skills/wingchiu-minimax-speech) - Manage MiniMax Speech 2.8 T2A (text-to-audio) and voice catalog lookups.
+- [mobilerun](https://github.com/openclaw/skills/tree/main/skills/johnmalek312/mobilerun/SKILL.md) - Control Android phones: tap, swipe, type, screenshot, automate apps.
 - [mukt](https://clawskills.sh/skills/hgosansn-mukt) - Zero-cost OpenRouter responder that auto-discovers the best currently free model, retries on failures, and returns.
 - [multilogin](https://clawskills.sh/skills/glebkazachinskiy-multilogin) - Use when you need to manage Multilogin X browser profiles — launch quick disposable profiles, list/start/stop saved.
 - [multiloginx](https://clawskills.sh/skills/multilogincom-multiloginx) - Use when you need to manage Multilogin X browser profiles — launch quick disposable profiles, list/start/stop saved.


### PR DESCRIPTION
## Skill: mobilerun

Control Android phones through the Mobilerun API — tap, swipe, type, take screenshots, read the UI tree, and manage apps. Hosted mobile cloud platform that grants AI-native control of Android devices for automation, QA, form-filling, data extraction, and workflow automation. iOS support coming soon.

### Links

- ClawHub: https://clawhub.ai/johnmalek312/mobilerun
- GitHub: https://github.com/openclaw/skills/tree/main/skills/johnmalek312/mobilerun

### Category

Browser & Automation

### Details

- **Author**: johnmalek312
- **Skill name**: mobilerun

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the skills catalogue count to 323.
  * Added the new "mobilerun" skill entry for Android device automation (tap, swipe, type, screenshots, and app interactions); note indicates iOS support is coming soon.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->