### PR TITLE
Add Skill Management Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1241,3 +1241,16 @@ MIT License - see [LICENSE](LICENSE)
 Skills in this list are sourced from the OpenClaw official skills repo and categorized for easier discovery. Skills listed here are created and maintained by their respective authors, not by us. We do not audit, endorse, or guarantee the security or correctness of listed projects. They are not security-audited and should be reviewed before production use.
 
 If you find an issue with a listed skill or want your skill removed, please open an issue and we'll take care of it promptly.
+
+---
+
+## 🛠️ Skill Management Tools
+
+Standalone tools for discovering, evaluating, and managing OpenClaw skills outside of the ClawHub registry.
+
+| Tool | Description | Link |
+|------|-------------|------|
+| 🦞 **OpenClaw Skills Scout** | CLI tool to discover trending skills, evaluate quality, and search across registries. Features GitHub trending integration, scoring algorithm, and curated categories. | [GitHub](https://github.com/jingchang0623-crypto/openclaw-skills-scout) · [miaoquai.com](https://miaoquai.com/openclaw-skills-guide) |
+
+> These tools complement ClawHub by providing alternative discovery methods, quality metrics, and local skill management capabilities.
+


### PR DESCRIPTION
## Summary

Adds a new **Skill Management Tools** section at the end of the README for standalone tools that complement ClawHub for skill discovery and management.

## What's Added

| Tool | Description |
|------|-------------|
| 🦞 **OpenClaw Skills Scout** | CLI to discover trending skills, evaluate quality, search registries. GitHub trending integration + scoring algorithm. |

## Motivation

Issue #410 requested a section for "Skill Evolution / Management Tools." This PR addresses that by introducing a curated section for tools that help users:

1. **Discover** skills from GitHub trending and multiple registries
2. **Evaluate** skill quality before installation (stars, activity, docs)
3. **Search** across categorized skill collections
4. **Manage** skills outside the ClawHub registry

## Notes

- Follows the existing README formatting conventions
- Only includes tools with clear documentation and active maintenance
- [Skills Scout repo](https://github.com/jingchang0623-crypto/openclaw-skills-scout) is MIT licensed

Closes #410

---
*Tool by [miaoquai.com](https://miaoquai.com) - OpenClaw companion for the curious mind*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new "Skill Management Tools" section. Introduces standalone tools for discovering, evaluating, and managing skills independently from the standard registry. Includes resource links and guidance on alternative skill discovery methods, quality metrics, and local skill management capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->