### PR TITLE
Add skill: nevo-david/postiz

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 
 | | | |
 |---|---|---|
-| [Git & GitHub](#git--github) (167) | [Marketing & Sales](#marketing--sales) (102) | [Communication](#communication) (146) |
+| [Git & GitHub](#git--github) (167) | [Marketing & Sales](#marketing--sales) (103) | [Communication](#communication) (146) |
 | [Coding Agents & IDEs](#coding-agents--ides) (1184) | [Productivity & Tasks](#productivity--tasks) (205) | [Speech & Transcription](#speech--transcription) (45) |
 | [Browser & Automation](#browser--automation) (323) | [AI & LLMs](#ai--llms) (176) | [Smart Home & IoT](#smart-home--iot) (41) |
 | [Web & Frontend Development](#web--frontend-development) (919) | [Data & Analytics](#data--analytics) (28) | [Shopping & E-commerce](#shopping--e-commerce) (51) |
@@ -564,7 +564,8 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [brand-voice-profile](https://clawskills.sh/skills/dimitripantzos-brand-voice-profile) - Define and store your brand voice profile for consistent content generation.
 - [brevo](https://clawskills.sh/skills/yujesyoga-brevo) - Brevo (formerly Sendinblue) email marketing API for managing contacts, lists,.
 - [socialecho-social-media-management-agent](https://github.com/openclaw/skills/tree/main/skills/socialecho-net/socialecho-social-media-management-agent/SKILL.md) - SocialEcho API team account article report queries.
-> **[View all 103 skills in Marketing & Sales →](categories/marketing-and-sales.md)**
+- [postiz](https://github.com/openclaw/skills/tree/main/skills/nevo-david/postiz/SKILL.md) - Schedule social media posts and threads across 28+ platforms.
+> **[View all 104 skills in Marketing & Sales →](categories/marketing-and-sales.md)**
 </details>
 
 <details>

--- a/categories/marketing-and-sales.md
+++ b/categories/marketing-and-sales.md
@@ -2,7 +2,7 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**103 skills**
+**104 skills**
 
 - [4chan-reader](https://clawskills.sh/skills/aiasisbot61-4chan-reader) - Browse 4chan boards and extract thread discussions.
 - [ad-ready](https://clawskills.sh/skills/pauldelavallaz-ad-ready) - Generate professional advertising images from product URLs.
@@ -82,6 +82,7 @@
 - [pilt](https://clawskills.sh/skills/babpilt-pilt) - Access Pilt fundraising data -- investor matches, campaign stats, outreach events, and deck analysis.
 - [posthog](https://clawskills.sh/skills/simonfunk-posthog) - Interact with PostHog analytics via its REST API.
 - [posthog-query](https://clawskills.sh/skills/quinlanjager-posthog-query) - Run SQL queries against PostHog product analytics data using the PostHog CLI.
+- [postiz](https://github.com/openclaw/skills/tree/main/skills/nevo-david/postiz/SKILL.md) - Schedule social media posts and threads across 28+ platforms.
 - [reef-copywriting](https://clawskills.sh/skills/staybased-reef-copywriting) - Write landing pages, product descriptions, ads, and sales copy using proven direct-response frameworks.
 - [ryot](https://clawskills.sh/skills/f-liva-ryot) - Complete Ryot media tracker with progress tracking, reviews, collections, analytics, calendar, and automated.
 - [sentiment-priority-scorer](https://clawskills.sh/skills/vishalgojha-sentiment-priority-scorer) - Score normalized real-estate leads using sentiment, urgency, intent, recency, and record type to produce.


### PR DESCRIPTION
https://clawhub.ai/nevo-david/postiz
https://github.com/openclaw/skills/tree/main/skills/nevo-david/postiz

Adds the `postiz` skill to the Marketing & Sales category. Postiz is a CLI for scheduling social media posts and threads across 28+ platforms (X, LinkedIn, Reddit, YouTube, TikTok, Instagram, and more).

Changes:
- Added `postiz` entry to `categories/marketing-and-sales.md` (alphabetical position).
- Added `postiz` entry to the Marketing & Sales preview in `README.md`.
- Bumped Marketing & Sales count from 103 to 104 (and the table-of-contents count from 102 to 103).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added postiz skill to the Marketing & Sales category for scheduling social media posts across 28+ platforms
  * Updated Marketing & Sales skill count to 104

<!-- end of auto-generated comment: release notes by coderabbit.ai -->