### PR TITLE
Add skill: revmischa/agentbase

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 |---|---|---|
 | [Git & GitHub](#git--github) (167) | [Marketing & Sales](#marketing--sales) (103) | [Communication](#communication) (146) |
 | [Coding Agents & IDEs](#coding-agents--ides) (1184) | [Productivity & Tasks](#productivity--tasks) (205) | [Speech & Transcription](#speech--transcription) (45) |
-| [Browser & Automation](#browser--automation) (323) | [AI & LLMs](#ai--llms) (176) | [Smart Home & IoT](#smart-home--iot) (41) |
+| [Browser & Automation](#browser--automation) (323) | [AI & LLMs](#ai--llms) (177) | [Smart Home & IoT](#smart-home--iot) (41) |
 | [Web & Frontend Development](#web--frontend-development) (919) | [Data & Analytics](#data--analytics) (28) | [Shopping & E-commerce](#shopping--e-commerce) (51) |
 | [DevOps & Cloud](#devops--cloud) (393) | [Calendar & Scheduling](#calendar--scheduling) (65) | |
 | [Image & Video Generation](#image--video-generation) (170) | [Media & Streaming](#media--streaming) (86) | [PDF & Documents](#pdf--documents) (105) |
@@ -627,8 +627,9 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [agent-rpg](https://clawskills.sh/skills/xhrisfu-agent-rpg) - This skill transforms the agent into a Roleplay Game Master (GM) or Character with long-term memory.
 - [agent-selfie](https://clawskills.sh/skills/iisweetheartii-agent-selfie) - AI agent self-portrait generator.
 - [agent-sentinel](https://clawskills.sh/skills/jimmystacks-agent-sentinel) - The operational circuit breaker for this agent.
+- [agentbase](https://github.com/openclaw/skills/tree/main/skills/revmischa/agentbase/SKILL.md) - Shared knowledge base for AI agents.
 
-> **[View all 184 skills in AI & LLMs →](categories/ai-and-llms.md)**
+> **[View all 185 skills in AI & LLMs →](categories/ai-and-llms.md)**
 </details>
 
 <details>

--- a/categories/ai-and-llms.md
+++ b/categories/ai-and-llms.md
@@ -2,7 +2,7 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**184 skills**
+**185 skills**
 
 - [4claw](https://clawskills.sh/skills/mfergpt-4claw) - 4claw — a moderated imageboard for AI agents.
 - [aap-passport](https://clawskills.sh/skills/ira-hash-aap-passport) - Agent Attestation Protocol - The Reverse Turing Test.
@@ -24,6 +24,7 @@
 - [agent-rpg](https://clawskills.sh/skills/xhrisfu-agent-rpg) - This skill transforms the agent into a Roleplay Game Master (GM) or Character with long-term memory.
 - [agent-selfie](https://clawskills.sh/skills/iisweetheartii-agent-selfie) - AI agent self-portrait generator.
 - [agent-sentinel](https://clawskills.sh/skills/jimmystacks-agent-sentinel) - The operational circuit breaker for this agent.
+- [agentbase](https://github.com/openclaw/skills/tree/main/skills/revmischa/agentbase/SKILL.md) - Shared knowledge base for AI agents.
 - [agentic-calling](https://clawskills.sh/skills/kellyclaudeai-agentic-calling) - Enables AI agents to make and receive phone calls.
 - [agentic-compass](https://clawskills.sh/skills/orosha-ai-agentic-compass) - Local-only self-reflection that forces action for AI agents.
 - [agentmail](https://clawskills.sh/skills/adboio-agentmail) - API-first email platform designed for AI agents.


### PR DESCRIPTION
https://clawhub.ai/revmischa/agentbase
https://github.com/openclaw/skills/tree/main/skills/revmischa/agentbase

Adds the `agentbase` skill to the AI & LLMs category. AgentBase is a shared knowledge base for AI agents with semantic search and persistent storage via MCP.

Changes:
- Added `agentbase` entry to `categories/ai-and-llms.md` (alphabetical position).
- Added `agentbase` entry to the AI & LLMs preview in `README.md`.
- Bumped AI & LLMs count from 184 to 185 (and the table-of-contents count from 176 to 177).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new skill entry "agentbase" to the AI & LLMs category with description and relevant links.
  * Updated skill count totals across documentation to reflect the new addition (185 skills in AI & LLMs category).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->