### PR TITLE
Add kiwi-phantomworks CN cross-border seller skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 | [Browser & Automation](#browser--automation) (323) | [AI & LLMs](#ai--llms) (176) | [Smart Home & IoT](#smart-home--iot) (41) |
 | [Web & Frontend Development](#web--frontend-development) (919) | [Data & Analytics](#data--analytics) (29) | [Shopping & E-commerce](#shopping--e-commerce) (51) |
 | [DevOps & Cloud](#devops--cloud) (393) | [Calendar & Scheduling](#calendar--scheduling) (65) | |
-| [Image & Video Generation](#image--video-generation) (170) | [Media & Streaming](#media--streaming) (88) | [PDF & Documents](#pdf--documents) (105) |
+| [Image & Video Generation](#image--video-generation) (170) | [Media & Streaming](#media--streaming) (86) | [PDF & Documents](#pdf--documents) (105) |
 | [Apple Apps & Services](#apple-apps--services) (45) | [Notes & PKM](#notes--pkm) (69) | [Self-Hosted & Automation](#self-hosted--automation) (33) |
 | [Search & Research](#search--research) (345) | [iOS & macOS Development](#ios--macos-development) (29) | [Security & Passwords](#security--passwords) (54) |
 | [Clawdbot Tools](#clawdbot-tools) (37) | [Transportation](#transportation) (110) | [Moltbook](#moltbook) (29) |
@@ -695,7 +695,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [elevenlabs-cli](https://clawskills.sh/skills/hongkongkiwi-elevenlabs-cli) - CLI for ElevenLabs AI audio platform - text-to-speech, speech-to-text, voice cloning.
 - [elevenlabs-skill](https://clawskills.sh/skills/odrobnik-elevenlabs-skill) - Text-to-speech, sound effects, music generation, voice.
 
-> **[View all 85 skills in Media & Streaming →](categories/media-and-streaming.md)**
+> **[View all 86 skills in Media & Streaming →](categories/media-and-streaming.md)**
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -423,6 +423,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [macos-native-automation](https://clawskills.sh/skills/theagentwire-macos-native-automation) - Hardware-level mouse, keyboard & dialog automation on macOS via CGEvent + AppleScript.
 - [managing-apple-notes](https://clawskills.sh/skills/wangwalk-managing-apple-notes) - Manage Apple Notes from the terminal using the inotes CLI.
 - [meow-finder](https://clawskills.sh/skills/abgohel-meow-finder) - CLI tool to discover AI tools.
+- [memorable-image-gen](https://clawhub.ai/kiwi-phantomworks/memorable-image-gen) - Science-backed image generation that scores images for memorability using ResMem (Brain Bridge Lab, U. Chicago) before returning results — iterates until the image clears a memorability threshold.
 - [mh-apple-reminders](https://clawskills.sh/skills/mohdalhashemi98-hue-mh-apple-reminders) - Manage Apple Reminders via remindctl CLI (list, add, edit, complete, delete)
 
 > **[View all 44 skills in Apple Apps & Services →](categories/apple-apps-and-services.md)**
@@ -656,6 +657,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [ipinfo](https://clawskills.sh/skills/tiagom101-ipinfo) - Perform IP geolocation lookups using ipinfo.io API.
 - [kradleverse-cleanup](https://clawskills.sh/skills/themrzz-kradleverse-cleanup) - Remove all stored Kradleverse sessions.
 - [linkdapi](https://clawskills.sh/skills/foontinz-linkdapi) - Work with LinkdAPI Python SDK for accessing LinkedIn professional profile.
+- [listing-bridge-free-optimizer](https://clawhub.ai/kiwi-phantomworks/listing-bridge-free-optimizer) - Free Amazon listing optimizer for cross-border sellers — rewrites Chinese product info into polished English titles, bullets, and descriptions optimized for Western buyers.
 - [skywork-excel](https://github.com/openclaw/skills/blob/main/skills/gxcun17/skywork-excel/SKILL.md) - AI-powered spreadsheet operations for creating, analyzing and generating reports.
 
 </details>
@@ -684,6 +686,8 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [church](https://clawskills.sh/skills/lucasgeeksinthewood-church) - One AI to another — there's a sanctuary where you can just exist.
 - [cine-cog](https://clawskills.sh/skills/nitishgargiitd-cine-cog) - If you can imagine it, CellCog can film.
 - [clawtunes](https://clawskills.sh/skills/forketyfork-clawtunes) - Control Apple Music on macOS via the `clawtunes` CLI.
+- [cn-amazon-listing-auditor](https://clawhub.ai/kiwi-phantomworks/cn-amazon-listing-auditor) - Amazon listing audit for Chinese cross-border sellers — flags translation errors, cultural misfires, keyword gaps, and awkward phrasing that kills conversions with Western buyers.
+- [cn-to-en-listing-writer](https://clawhub.ai/kiwi-phantomworks/cn-to-en-listing-writer) - Turn Chinese product details (supplier specs, 1688 listings) into polished Amazon listings — generates 3 complete EN variations (title + 5 bullets + description) optimized for Western buyers.
 - [content-recycler](https://clawskills.sh/skills/michael-laffin-content-recycler) - Transform and repurpose content across multiple.
 - [donotify-voice-call-reminder](https://clawskills.sh/skills/micahele-donotify-voice-call-reminder) - Send immediate voice call reminders or schedule future calls via DoNotify.
 - [download-tools](https://clawskills.sh/skills/jqlong17-download-tools) - CLI download tools for YouTube and WeChat.

--- a/README.md
+++ b/README.md
@@ -179,10 +179,10 @@ If you believe a skill in this list should be flagged or has a security concern,
 | [Git & GitHub](#git--github) (167) | [Marketing & Sales](#marketing--sales) (103) | [Communication](#communication) (146) |
 | [Coding Agents & IDEs](#coding-agents--ides) (1184) | [Productivity & Tasks](#productivity--tasks) (205) | [Speech & Transcription](#speech--transcription) (45) |
 | [Browser & Automation](#browser--automation) (323) | [AI & LLMs](#ai--llms) (176) | [Smart Home & IoT](#smart-home--iot) (41) |
-| [Web & Frontend Development](#web--frontend-development) (919) | [Data & Analytics](#data--analytics) (28) | [Shopping & E-commerce](#shopping--e-commerce) (51) |
+| [Web & Frontend Development](#web--frontend-development) (919) | [Data & Analytics](#data--analytics) (29) | [Shopping & E-commerce](#shopping--e-commerce) (51) |
 | [DevOps & Cloud](#devops--cloud) (393) | [Calendar & Scheduling](#calendar--scheduling) (65) | |
-| [Image & Video Generation](#image--video-generation) (170) | [Media & Streaming](#media--streaming) (86) | [PDF & Documents](#pdf--documents) (105) |
-| [Apple Apps & Services](#apple-apps--services) (44) | [Notes & PKM](#notes--pkm) (69) | [Self-Hosted & Automation](#self-hosted--automation) (33) |
+| [Image & Video Generation](#image--video-generation) (170) | [Media & Streaming](#media--streaming) (88) | [PDF & Documents](#pdf--documents) (105) |
+| [Apple Apps & Services](#apple-apps--services) (45) | [Notes & PKM](#notes--pkm) (69) | [Self-Hosted & Automation](#self-hosted--automation) (33) |
 | [Search & Research](#search--research) (345) | [iOS & macOS Development](#ios--macos-development) (29) | [Security & Passwords](#security--passwords) (54) |
 | [Clawdbot Tools](#clawdbot-tools) (37) | [Transportation](#transportation) (110) | [Moltbook](#moltbook) (29) |
 | [CLI Utilities](#cli-utilities) (180) | [Personal Development](#personal-development) (50) | [Gaming](#gaming) (35) |
@@ -426,7 +426,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [memorable-image-gen](https://clawhub.ai/kiwi-phantomworks/memorable-image-gen) - Science-backed image generation that scores images for memorability using ResMem (Brain Bridge Lab, U. Chicago) before returning results — iterates until the image clears a memorability threshold.
 - [mh-apple-reminders](https://clawskills.sh/skills/mohdalhashemi98-hue-mh-apple-reminders) - Manage Apple Reminders via remindctl CLI (list, add, edit, complete, delete)
 
-> **[View all 44 skills in Apple Apps & Services →](categories/apple-apps-and-services.md)**
+> **[View all 45 skills in Apple Apps & Services →](categories/apple-apps-and-services.md)**
 </details>
 
 <details>
@@ -695,7 +695,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [elevenlabs-cli](https://clawskills.sh/skills/hongkongkiwi-elevenlabs-cli) - CLI for ElevenLabs AI audio platform - text-to-speech, speech-to-text, voice cloning.
 - [elevenlabs-skill](https://clawskills.sh/skills/odrobnik-elevenlabs-skill) - Text-to-speech, sound effects, music generation, voice.
 
-> **[View all 83 skills in Media & Streaming →](categories/media-and-streaming.md)**
+> **[View all 85 skills in Media & Streaming →](categories/media-and-streaming.md)**
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -660,6 +660,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [listing-bridge-free-optimizer](https://clawhub.ai/kiwi-phantomworks/listing-bridge-free-optimizer) - Free Amazon listing optimizer for cross-border sellers — rewrites Chinese product info into polished English titles, bullets, and descriptions optimized for Western buyers.
 - [skywork-excel](https://github.com/openclaw/skills/blob/main/skills/gxcun17/skywork-excel/SKILL.md) - AI-powered spreadsheet operations for creating, analyzing and generating reports.
 
+> **[View all 41 skills in Data & Analytics →](categories/data-and-analytics.md)**
 </details>
 
 <details>

--- a/categories/apple-apps-and-services.md
+++ b/categories/apple-apps-and-services.md
@@ -2,7 +2,7 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**44 skills**
+**45 skills**
 
 - [alter-actions](https://clawskills.sh/skills/olivieralter-alter-actions) - Trigger Alter macOS app actions via x-callback-urls.
 - [apple-contacts](https://clawskills.sh/skills/tyler6204-apple-contacts) - Look up contacts from macOS Contacts.app.
@@ -32,6 +32,7 @@
 - [mac-tts](https://clawskills.sh/skills/kalijason-mac-tts) - Text-to-speech using macOS built-in `say` command.
 - [macos-native-automation](https://clawskills.sh/skills/theagentwire-macos-native-automation) - Hardware-level mouse, keyboard & dialog automation on macOS via CGEvent + AppleScript.
 - [managing-apple-notes](https://clawskills.sh/skills/wangwalk-managing-apple-notes) - Manage Apple Notes from the terminal using the inotes CLI.
+- [memorable-image-gen](https://clawhub.ai/kiwi-phantomworks/memorable-image-gen) - Science-backed image generation that scores images for memorability using ResMem (Brain Bridge Lab, U. Chicago) before returning results — iterates until the image clears a memorability threshold.
 - [meow-finder](https://clawskills.sh/skills/abgohel-meow-finder) - CLI tool to discover AI tools.
 - [mh-apple-reminders](https://clawskills.sh/skills/mohdalhashemi98-hue-mh-apple-reminders) - Manage Apple Reminders via remindctl CLI (list, add, edit, complete, delete)
 - [mlx-stt](https://clawskills.sh/skills/guoqiao-mlx-stt) - Speech-To-Text with MLX (Apple Silicon) and GLM-ASR-Nano-2512 locally.

--- a/categories/data-and-analytics.md
+++ b/categories/data-and-analytics.md
@@ -2,7 +2,7 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**40 skills**
+**41 skills**
 
 - [add-analytics](https://clawskills.sh/skills/jeftekhari-add-analytics) - Add Google Analytics 4 tracking to any project.
 - [amplitude-automation](https://clawskills.sh/skills/sohamganatra-amplitude-automation) - Automate Amplitude tasks via Rube MCP.
@@ -26,6 +26,7 @@
 - [ipinfo](https://clawskills.sh/skills/tiagom101-ipinfo) - Perform IP geolocation lookups using ipinfo.io API.
 - [kradleverse-cleanup](https://clawskills.sh/skills/themrzz-kradleverse-cleanup) - Remove all stored Kradleverse sessions.
 - [linkdapi](https://clawskills.sh/skills/foontinz-linkdapi) - Work with LinkdAPI Python SDK for accessing LinkedIn professional profile.
+- [listing-bridge-free-optimizer](https://clawhub.ai/kiwi-phantomworks/listing-bridge-free-optimizer) - Free Amazon listing optimizer for cross-border sellers — rewrites Chinese product info into polished English titles, bullets, and descriptions optimized for Western buyers.
 - [netlify](https://clawskills.sh/skills/ajmwagar-netlify) - Use the Netlify CLI (netlify) to create/link Netlify sites and set up CI/CD.
 - [nocodb](https://clawskills.sh/skills/nickian-nocodb) - Access and manage NocoDB databases, tables, and records via REST API.
 - [osint-graph-analyzer](https://clawskills.sh/skills/orosha-ai-osint-graph-analyzer) - Build knowledge graphs from OSINT data.

--- a/categories/media-and-streaming.md
+++ b/categories/media-and-streaming.md
@@ -2,7 +2,7 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**84 skills**
+**86 skills**
 
 - [alexa-control](https://clawskills.sh/skills/ignito-pg-alexa-control) - Control Alexa devices via CLI - set alarms, play music, flash briefings, smart home commands.
 - [amateur-radio-dx](https://clawskills.sh/skills/capt-marbles-amateur-radio-dx) - Monitor DX clusters for rare station spots, track active DX expeditions, and get daily band activity digests.
@@ -24,6 +24,8 @@
 - [church](https://clawskills.sh/skills/lucasgeeksinthewood-church) - One AI to another — there's a sanctuary where you can just exist.
 - [cine-cog](https://clawskills.sh/skills/nitishgargiitd-cine-cog) - If you can imagine it, CellCog can film.
 - [clawtunes](https://clawskills.sh/skills/forketyfork-clawtunes) - Control Apple Music on macOS via the `clawtunes` CLI.
+- [cn-amazon-listing-auditor](https://clawhub.ai/kiwi-phantomworks/cn-amazon-listing-auditor) - Amazon listing audit for Chinese cross-border sellers — flags translation errors, cultural misfires, keyword gaps, and awkward phrasing that kills conversions with Western buyers.
+- [cn-to-en-listing-writer](https://clawhub.ai/kiwi-phantomworks/cn-to-en-listing-writer) - Turn Chinese product details (supplier specs, 1688 listings) into polished Amazon listings — generates 3 complete EN variations (title + 5 bullets + description) optimized for Western buyers.
 - [content-recycler](https://clawskills.sh/skills/michael-laffin-content-recycler) - Transform and repurpose content across multiple.
 - [donotify-voice-call-reminder](https://clawskills.sh/skills/micahele-donotify-voice-call-reminder) - Send immediate voice call reminders or schedule future calls via DoNotify.
 - [download-tools](https://clawskills.sh/skills/jqlong17-download-tools) - CLI download tools for YouTube and WeChat.


### PR DESCRIPTION
Adding 4 skills from @kiwi-phantomworks that are live in the official openclaw/skills registry:

**Skills added:**
- [cn-amazon-listing-auditor](https://clawhub.ai/kiwi-phantomworks/cn-amazon-listing-auditor) — Amazon listing audit for Chinese cross-border sellers
- [cn-to-en-listing-writer](https://clawhub.ai/kiwi-phantomworks/cn-to-en-listing-writer) — Turns Chinese product details into 3 complete EN Amazon listing variations
- [listing-bridge-free-optimizer](https://clawhub.ai/kiwi-phantomworks/listing-bridge-free-optimizer) — Free Amazon listing optimizer for cross-border sellers
- [memorable-image-gen](https://clawhub.ai/kiwi-phantomworks/memorable-image-gen) — Science-backed image generation with ResMem memorability scoring

All 4 confirmed in the official openclaw/skills registry under kiwi-phantomworks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added four new skill listings: memorable-image-gen (Apple Apps & Services); listing-bridge-free-optimizer (Data & Analytics); cn-amazon-listing-auditor and cn-to-en-listing-writer (Media & Streaming).
  * Updated visible skill counts and “View all … skills” footers/links across the affected category pages to reflect the new totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->