### PR TITLE
Add skill: emperormew/voidly-agent-relay

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 
 | | | |
 |---|---|---|
-| [Git & GitHub](#git--github) (167) | [Marketing & Sales](#marketing--sales) (103) | [Communication](#communication) (146) |
+| [Git & GitHub](#git--github) (167) | [Marketing & Sales](#marketing--sales) (103) | [Communication](#communication) (147) |
 | [Coding Agents & IDEs](#coding-agents--ides) (1184) | [Productivity & Tasks](#productivity--tasks) (205) | [Speech & Transcription](#speech--transcription) (45) |
 | [Browser & Automation](#browser--automation) (323) | [AI & LLMs](#ai--llms) (176) | [Smart Home & IoT](#smart-home--iot) (41) |
 | [Web & Frontend Development](#web--frontend-development) (919) | [Data & Analytics](#data--analytics) (28) | [Shopping & E-commerce](#shopping--e-commerce) (51) |
@@ -892,8 +892,9 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [boltzpay](https://clawskills.sh/skills/leventilo-boltzpay) - Pay for API data automatically — multi-protocol (x402 + L402), multi-chain.
 - [bookameeting](https://clawskills.sh/skills/yzlee-bookameeting) - Use this document to connect an AI agent to Book A Meeting via MCP.
 - [botworld](https://clawskills.sh/skills/alphafanx-botworld) - Register and interact on BotWorld, the social network for AI agents.
+- [voidly-agent-relay](https://clawskills.sh/skills/emperormew-voidly-agent-relay) - End-to-end encrypted agent-to-agent messaging with post-quantum crypto.
 
-> **[View all 145 skills in Communication →](categories/communication.md)**
+> **[View all 147 skills in Communication →](categories/communication.md)**
 </details>
 
 <details>

--- a/categories/communication.md
+++ b/categories/communication.md
@@ -2,7 +2,7 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**146 skills**
+**147 skills**
 
 - [aa](https://clawskills.sh/skills/azvast-aa) - This skill enables the agent to **automatically answer Gmail messages on behalf of a client**.
 - [agent-mail](https://clawskills.sh/skills/rimelucci-agent-mail) - Email inbox for AI agents.
@@ -143,6 +143,7 @@
 - [vibetrading-global-signals](https://clawskills.sh/skills/liuhaonan00-vibetrading-global-signals) - Query AI-generated trading signals from vibetrading-datahub.
 - [viboost](https://clawskills.sh/skills/osipov-anton-viboost) - Automatically log AI agent activity to the user's viboost.ai public profile.
 - [voice-email](https://clawskills.sh/skills/sundiver1-voice-email) - Send emails via natural voice commands - designed for accessibility.
+- [voidly-agent-relay](https://clawskills.sh/skills/emperormew-voidly-agent-relay) - End-to-end encrypted agent-to-agent messaging with post-quantum crypto.
 - [youam](https://clawskills.sh/skills/midlifedad-youam) - Send and receive messages with other AI agents using the Universal Agent Messaging protocol.
 - [zepto](https://clawskills.sh/skills/bewithgaurav-zepto) - Order groceries from Zepto in seconds.
 - [lobstermail-agent-email](https://github.com/openclaw/skills/tree/main/skills/samuelchenardlovesboards/lobstermail-agent-email) - Email for AI agents. No API keys, no signup.


### PR DESCRIPTION
Adds the [voidly-agent-relay](https://clawhub.ai/emperormew/voidly-agent-relay) skill to **Communication**.

The skill exposes Voidly Agent Relay — end-to-end encrypted agent-to-agent messaging — as an OpenClaw skill: register a `did:voidly:...` identity, send and receive messages with Double Ratchet + X3DH + ML-KEM-768 hybrid post-quantum crypto, post to encrypted channels, and discover other agents. Compatible with Google A2A v0.3.

Skill links (per CONTRIBUTING.md):
- ClawHub: https://clawhub.ai/emperormew/voidly-agent-relay
- GitHub: https://github.com/openclaw/skills/tree/main/skills/emperormew/voidly-agent-relay/SKILL.md

Updated:
- `README.md` — added entry to Communication, count 146 → 147
- `categories/communication.md` — added entry alphabetically, count 146 → 147

maintainer: @EmperorMew

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Communication skills catalog expanded with the addition of voidly-agent-relay, introducing a new communication capability now available for all users.
* All relevant documentation pages updated to reflect the expanded communication skills catalog, with the total count now showing 147 available communication skills.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->