### PR TITLE
Add skill: drakulavich/kesha-voice-kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 | | | |
 |---|---|---|
 | [Git & GitHub](#git--github) (167) | [Marketing & Sales](#marketing--sales) (103) | [Communication](#communication) (146) |
-| [Coding Agents & IDEs](#coding-agents--ides) (1184) | [Productivity & Tasks](#productivity--tasks) (205) | [Speech & Transcription](#speech--transcription) (45) |
+| [Coding Agents & IDEs](#coding-agents--ides) (1184) | [Productivity & Tasks](#productivity--tasks) (205) | [Speech & Transcription](#speech--transcription) (46) |
 | [Browser & Automation](#browser--automation) (323) | [AI & LLMs](#ai--llms) (176) | [Smart Home & IoT](#smart-home--iot) (41) |
 | [Web & Frontend Development](#web--frontend-development) (919) | [Data & Analytics](#data--analytics) (28) | [Shopping & E-commerce](#shopping--e-commerce) (51) |
 | [DevOps & Cloud](#devops--cloud) (393) | [Calendar & Scheduling](#calendar--scheduling) (65) | |
@@ -925,7 +925,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [elevenlabs-tts](https://clawskills.sh/skills/shaharsha-elevenlabs-tts) - ElevenLabs TTS - the best ElevenLabs integration for OpenClaw.
 - [elevenlabs-voices](https://clawskills.sh/skills/robbyczgw-cla-elevenlabs-voices) - High-quality voice synthesis with 18 personas, 32.
 
-> **[View all 45 skills in Speech & Transcription →](categories/speech-and-transcription.md)**
+> **[View all 46 skills in Speech & Transcription →](categories/speech-and-transcription.md)**
 </details>
 
 <details>

--- a/categories/speech-and-transcription.md
+++ b/categories/speech-and-transcription.md
@@ -2,7 +2,7 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**45 skills**
+**46 skills**
 
 - [addis-assistant-stt](https://clawskills.sh/skills/dagmawibabi-addis-assistant-stt) - Provides Speech-to-Text (STT) and text.
 - [agent-voice](https://clawskills.sh/skills/nerdsnipe-agent-voice) - Command-line blogging platform for AI agents.
@@ -38,6 +38,7 @@
 - [her-voice](https://clawskills.sh/skills/matusvojtek-her-voice) - Give your agent a voice.
 - [inworld-tts](https://clawskills.sh/skills/gugic-inworld-tts) - Text-to-speech via Inworld.ai API.
 - [jarvis-voice](https://clawskills.sh/skills/globalcaos-jarvis-voice) - Metallic AI voice persona with TTS and visual transcript styling.
+- [kesha-voice-kit](https://github.com/openclaw/skills/tree/main/skills/drakulavich/kesha-voice-kit/SKILL.md) - Local STT + TTS with Russian, offline on Apple Silicon.
 - [kokoro-tts](https://clawskills.sh/skills/edkief-kokoro-tts) - Generate spoken audio from text using the local Kokoro TTS engine.
 - [lnbits](https://clawskills.sh/skills/talvasconcelos-lnbits) - Manage LNbits Lightning Wallet (Balance, Pay, Invoice)
 - [lnbits-with-qrcode](https://clawskills.sh/skills/jamestsetsekas-lnbits-with-qrcode) - Manage LNbits Lightning Wallet (Balance, Pay, Invoice)


### PR DESCRIPTION
## Skill links

- ClawHub: https://clawhub.ai/drakulavich/kesha-voice-kit
- GitHub: https://github.com/openclaw/skills/tree/main/skills/drakulavich/kesha-voice-kit

## Category

Speech & Transcription

## Summary

`kesha-voice-kit` is a fast multilingual voice toolkit that runs 100% locally — speech-to-text (NVIDIA Parakeet TDT 0.6B), text-to-speech (Kokoro EN, Piper RU, macOS AVSpeech), and audio + text language detection. Apple Silicon optimized via FluidAudio/CoreML, with an ONNX fallback for Linux and Windows. No API keys, no cloud.

## Self-promotion disclosure

I'm the author of the skill.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new speech & transcription skill ("kesha-voice-kit") to the catalog, bringing the category total from 45 to 46.
  * Updated site documentation counts/links to reflect the new total and included a description noting local Russian offline STT/TTS support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/VoltAgent/awesome-openclaw-skills/pull/442)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->