### PR TITLE
Add skill: flotapponnier/mobula-mpp

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 
 | | | |
 |---|---|---|
-| [Git & GitHub](#git--github) (167) | [Marketing & Sales](#marketing--sales) (103) | [Communication](#communication) (146) |
+| [Git & GitHub](#git--github) (167) | [Marketing & Sales](#marketing--sales) (104) | [Communication](#communication) (146) |
 | [Coding Agents & IDEs](#coding-agents--ides) (1184) | [Productivity & Tasks](#productivity--tasks) (205) | [Speech & Transcription](#speech--transcription) (45) |
 | [Browser & Automation](#browser--automation) (323) | [AI & LLMs](#ai--llms) (176) | [Smart Home & IoT](#smart-home--iot) (41) |
 | [Web & Frontend Development](#web--frontend-development) (919) | [Data & Analytics](#data--analytics) (28) | [Shopping & E-commerce](#shopping--e-commerce) (51) |
@@ -565,7 +565,8 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [brevo](https://clawskills.sh/skills/yujesyoga-brevo) - Brevo (formerly Sendinblue) email marketing API for managing contacts, lists,.
 - [socialecho-social-media-management-agent](https://github.com/openclaw/skills/tree/main/skills/socialecho-net/socialecho-social-media-management-agent/SKILL.md) - SocialEcho API team account article report queries.
 - [postiz](https://github.com/openclaw/skills/tree/main/skills/nevo-david/postiz/SKILL.md) - Schedule social media posts and threads across 28+ platforms.
-> **[View all 104 skills in Marketing & Sales →](categories/marketing-and-sales.md)**
+- [mobula-mpp](https://github.com/openclaw/skills/tree/main/skills/flotapponnier/mobula-mpp/SKILL.md) - Subscribe to Mobula MPP plans, fetch crypto prices, wallet data, and execute trades.
+> **[View all 105 skills in Marketing & Sales →](categories/marketing-and-sales.md)**
 </details>
 
 <details>

--- a/categories/marketing-and-sales.md
+++ b/categories/marketing-and-sales.md
@@ -2,7 +2,7 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**104 skills**
+**105 skills**
 
 - [4chan-reader](https://clawskills.sh/skills/aiasisbot61-4chan-reader) - Browse 4chan boards and extract thread discussions.
 - [ad-ready](https://clawskills.sh/skills/pauldelavallaz-ad-ready) - Generate professional advertising images from product URLs.
@@ -72,6 +72,7 @@
 - [meta-ads-report](https://clawskills.sh/skills/kein-s-meta-ads-report) - A powerful toolkit to monitor your Meta (Facebook/Instagram) advertising performance directly through chat.
 - [meta-tags-optimizer](https://clawskills.sh/skills/aaron-he-zhu-meta-tags-optimizer) - Use when the user asks to "optimize title tag", "write meta description", "improve CTR", "Open Graph tags", "social.
 - [mobula](https://clawskills.sh/skills/flotapponnier-mobula) - Real-time crypto market data, wallet portfolio tracking, and token analytics across 88+ blockchains.
+- [mobula-mpp](https://github.com/openclaw/skills/tree/main/skills/flotapponnier/mobula-mpp/SKILL.md) - Subscribe to Mobula MPP plans, fetch crypto prices, wallet data, and execute trades.
 - [near-agent-skills](https://clawskills.sh/skills/mastrophot-near-agent-skills) - Comprehensive agentic skills for NEAR Protocol, including gas optimization and on-chain analytics.
 - [nicholasrae-review-reply](https://clawskills.sh/skills/nicholasrae-nicholasrae-review-reply) - Automatically monitors your App Store reviews and drafts warm, on-brand replies for 1–3 star reviews — so unhappy.
 - [odoo-reporting](https://clawskills.sh/skills/ashrf-in-odoo-reporting) - Query Odoo data including salesperson performance, customer analytics, orders, invoices, CRM, accounting, VAT.


### PR DESCRIPTION
## Adding Mobula MPP skill

Adds the Mobula MPP (Machine Payments Protocol) skill to the **Marketing & Sales** category.

### Skill links
- GitHub: https://github.com/openclaw/skills/tree/main/skills/flotapponnier/mobula-mpp
- ClawHub: https://clawhub.ai/flotapponnier/mobula-mpp

### Description
Subscribe to Mobula MPP plans, fetch crypto prices, wallet data, and execute trades.

### Changes
- Added entry in `categories/marketing-and-sales.md` (104 → 105 skills)
- Added entry + updated counts in `README.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new mobula-mpp skill entry to the Marketing & Sales category
  * Updated category skill list with corresponding documentation and references
  * Incremented Marketing & Sales total skill count from 104 to 105

<!-- end of auto-generated comment: release notes by coderabbit.ai -->