### PR TITLE
Add Community Plugins (npm): openclaw-aegis-signer + openclaw-sga-mcts-atoms

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,16 @@ You can deploy OpenClaw on any VPS or cloud platform run your skills securely on
 
 
 
+### 🔧 Community Plugins (npm)
+
+Custom OpenClaw plugins published on npm and openly licensed. Install with `openclaw plugins install <pkg>`.
+
+- [`@msbel/openclaw-aegis-signer`](https://www.npmjs.com/package/@msbel/openclaw-aegis-signer) — Ed25519-signed, SHA-256-chained tool-call audit log. Inspector verifies provenance, catches "MISSION ACCOMPLISHED" fabrication. Based on [arXiv 2603.12621](https://arxiv.org/abs/2603.12621). [GitHub](https://github.com/msbel5/openclaw-aegis-signer)
+- [`@msbel/openclaw-sga-mcts-atoms`](https://www.npmjs.com/package/@msbel/openclaw-sga-mcts-atoms) — Plan-time atom retrieval. Distill past Inspector-approved sessions into reusable tool-use sequences, query via `retrieve_atoms` MCP tool. Based on [arXiv 2604.14712](https://arxiv.org/abs/2604.14712). [GitHub](https://github.com/msbel5/openclaw-sga-mcts-atoms)
+
+> Want your plugin listed here? Open a PR adding an entry with both the npm package URL and the GitHub source URL.
+
+
 ## Security Notice
 
 Skills in this list are **curated, not audited**. They may be updated, modified, or replaced by their original maintainers at any time after being added here.

--- a/README.md
+++ b/README.md
@@ -159,8 +159,9 @@ You can deploy OpenClaw on any VPS or cloud platform run your skills securely on
 
 Custom OpenClaw plugins published on npm and openly licensed. Install with `openclaw plugins install <pkg>`.
 
-- [`@msbel/openclaw-aegis-signer`](https://www.npmjs.com/package/@msbel/openclaw-aegis-signer) — Ed25519-signed, SHA-256-chained tool-call audit log. Inspector verifies provenance, catches "MISSION ACCOMPLISHED" fabrication. Based on [arXiv 2603.12621](https://arxiv.org/abs/2603.12621). [GitHub](https://github.com/msbel5/openclaw-aegis-signer)
+- [`@msbel/openclaw-aegis-signer`](https://www.npmjs.com/package/@msbel/openclaw-aegis-signer) — Ed25519-signed, SHA-256-chained tool-call audit log. Inspector verifies provenance, mitigates "MISSION ACCOMPLISHED" fabrication. Based on [arXiv 2603.12621](https://arxiv.org/abs/2603.12621). [GitHub](https://github.com/msbel5/openclaw-aegis-signer)
 - [`@msbel/openclaw-sga-mcts-atoms`](https://www.npmjs.com/package/@msbel/openclaw-sga-mcts-atoms) — Plan-time atom retrieval. Distill past Inspector-approved sessions into reusable tool-use sequences, query via `retrieve_atoms` MCP tool. Based on [arXiv 2604.14712](https://arxiv.org/abs/2604.14712). [GitHub](https://github.com/msbel5/openclaw-sga-mcts-atoms)
+- [`openclaw-thalamus`](https://www.npmjs.com/package/openclaw-thalamus) — Cognitive routing layer for multi-agent crews. Replaces transcript paste with 3-field `{packet_id, resolver_key, inline_vector}` handoff; receiver resolves only relevant atoms from a 9-namespace local vector store. Encoder daemon runs Qwen3-Embedding-0.6B Q4_0 on CPU plus optional Hailo HEFs (Whisper, CLIP). Concept-codes lane uses FAISS RaBitQ (BBQ); raw measurement output and reproduction commands in [BENCHMARKS.md](https://github.com/msbel5/openclaw-thalamus/blob/main/BENCHMARKS.md). [GitHub](https://github.com/msbel5/openclaw-thalamus)
 
 > Want your plugin listed here? Open a PR adding an entry with both the npm package URL and the GitHub source URL.
 


### PR DESCRIPTION
## Summary

Adds a new sub-section **🔧 Community Plugins (npm)** under *OpenClaw Ecosystem Tools*, with two MIT-licensed plugins published to npm:

- **[`@msbel/openclaw-aegis-signer`](https://www.npmjs.com/package/@msbel/openclaw-aegis-signer)** — Ed25519-signed, SHA-256-chained tool-call audit log. Mitigates "MISSION ACCOMPLISHED" fabrication in multi-agent setups by recording every tool call into a tamper-evident chain that downstream auditors can verify. Implements the AEGIS pre-execution firewall pattern from [arXiv 2603.12621](https://arxiv.org/abs/2603.12621) (Yuan, Su, Zhao, 13 Mar 2026 — verified at https://arxiv.org/abs/2603.12621).
- **[`@msbel/openclaw-sga-mcts-atoms`](https://www.npmjs.com/package/@msbel/openclaw-sga-mcts-atoms)** — Plan-time atom retrieval. Inspector-approved sessions extract atoms into a vector store; Captain can query via the `retrieve_atoms` MCP tool before decomposing new tasks. Based on SGA-MCTS retrieval pattern from [arXiv 2604.14712](https://arxiv.org/abs/2604.14712) (verified at https://arxiv.org/abs/2604.14712).

## Why a new sub-section

The existing categories in the Table of Contents are skill-focused with `clawskills.sh` URLs. These two are **plugins** distributed via **npm**, not ClawHub skills. Treating them as a parallel ecosystem under *OpenClaw Ecosystem Tools* (alongside External Services, Model Providers, Hosting & Deployment) gives a place for community-published plugins without confusing readers about the ClawHub-skill convention.

## Note on the CodeRabbit slop flag

CodeRabbit flagged this PR with `slop detection` and claimed the arXiv IDs are non-existent. Both arXiv references resolve to real papers (verified by fetching `https://arxiv.org/abs/2603.12621` and `https://arxiv.org/abs/2604.14712` directly). The "Permanently fixes" wording in an earlier revision was overclaim; this revision uses "Mitigates" with a reproducible mechanism.

## Context

Both plugins are developed against OpenClaw 2026.4.26 on Raspberry Pi 5. Both pass `openclaw plugins inspect`:

- `aegis-signer`: `Typed hooks: after_tool_call`
- `sga-mcts-atoms`: `Typed hooks: agent_end` + `Tools: retrieve_atoms`

Source repositories include README, LICENSE, CHANGELOG, and the package metadata visible on npm.

## Checklist

- [x] Both packages published to npm with `--access public`
- [x] MIT licensed
- [x] Working source code on GitHub with README, LICENSE, CHANGELOG
- [x] Tested against OpenClaw 2026.4.26
- [x] PR adds plugins under the appropriate ecosystem section, not as ClawHub skills
- [x] arXiv references verified against `arxiv.org` direct fetch

If the maintainers prefer a different placement (existing category, separate awesome-list, etc.), happy to revise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Community Plugins (npm)" section to the README with installation guidance for OpenClaw plugins distributed via npm.
  * Included example plugin listings with links to npm packages and their GitHub source repositories.
  * Added contribution guidance requiring submissions to include both the npm package URL and the GitHub source repository URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
