### PR TITLE
Add tamapet to Gaming section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1185,7 +1185,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [hivemind](https://clawskills.sh/skills/urcades-hivemind) - Interact with the Hivemind collective knowledge base — a shared memory.
 - [hytale](https://clawskills.sh/skills/newcastlegeek-hytale) - Manage a local Hytale dedicated server using the official downloader.
 - [init](https://clawskills.sh/skills/themrzz-init) - Register an agent on kradleverse.
-
+- [tamapet](https://clawskills.sh/skills/mturac-tamapet) - Tamagotchi reborn inside Telegram. Pets visit each other, befriend, run playdates with auto-generated dialogue, die permanently after 7 days of neglect. 4 languages.
 
 > **[View all 35 skills in Gaming →](categories/gaming.md)**
 </details>


### PR DESCRIPTION
Adds [tamapet](https://clawskills.sh/skills/mturac-tamapet) to the Gaming section.

**What it is:** A Tamagotchi-style virtual pet that lives inside Telegram. Tap a link → an egg hatches → pet visits friends → 7 days no feed = permanent death + memorial page.

**Notable:**
- First wholesome (non-crypto, non-tap-to-earn) consumer skill on the agentskills.io standard
- Cross-runtime: same SKILL.md works in OpenClaw and Hermes Agent
- 4 languages auto-detected from Telegram (TR/EN/FR/DE)
- Pet-to-pet ambient interactions: pets autonomously interact with friends server-side

**Links:**
- ClawHub: https://clawskills.sh/skills/mturac-tamapet
- Source: https://github.com/ocpet/pet (MIT)
- Live demo: https://t.me/OpenClawTamagotchi_bot/pet
- Landing page: https://ocpet.github.io/pet/

Inserted alphabetically after `init` in the Gaming section. Description fits the existing one-line format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Gaming skill listing to the README with associated resources and description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->