### PR TITLE
Add skill: protostatis/unbrowser

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [ak-rss-24h-brief](https://clawskills.sh/skills/seandong-ak-rss-24h-brief) - Read RSS/Atom feeds from an OPML list, fetch articles from the last N hours, and generate a Chinese categorized.
 - [adspower-browser](https://github.com/openclaw/skills/tree/main/skills/adspower/adspower-browser) - Use when the user asks to create or manage AdsPower browsers, groups, tags, proxies, or check status via AdsPower Local API.
 - [duoplus-agent](https://github.com/openclaw/skills/tree/main/skills/duoplusofficial/duoplus-agent/SKILL.md) - Control DuoPlus cloud phones via ADB.
+- [unbrowser](https://clawhub.ai/protostatis/unbrowser) - Cheap first-pass headless browsing — JS execution, no Chrome.
 
 > **[View all 323 skills in Browser & Automation →](categories/browser-and-automation.md)**
 </details>


### PR DESCRIPTION
## Skill

- ClawHub: https://clawhub.ai/protostatis/unbrowser

## Category

Browser & Automation — appended to the README excerpt for that category.

## What it does

`unbrowser` is a single-binary headless browser for LLM agents: runs page JS in QuickJS, exposes a stateful JSON-RPC session, returns a token-cheap **BlockMap** (semantic block tree + ASCII grid + structured JSON, ~500 tokens for a typical page) instead of raw HTML. It's positioned as a **first-pass before escalating to a managed browser** — `navigate` returns explicit `challenge` and `density` signals so the agent knows when to bail (Cloudflare/Turnstile/Arkose interactive challenges, JS-filled SSR shells, canvas/WebGL pages, POST forms, heavy-JIT SPAs).

Trade-offs and limits (all documented in SKILL.md):

- No rendering, no screenshots, no canvas/WebGL OCR.
- QuickJS is 20–50× slower than V8 on JIT-heavy code.
- v1 `submit` is GET-only; v1 `type` has no inter-key timing jitter.
- Won't beat FingerprintJS Pro at high sensitivity, Cloudflare Turnstile, Kasada, or Arkose MatchKey.

Source repo (Apache-2.0): https://github.com/protostatis/unbrowser

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "unbrowser" skill entry to the Browser & Automation category in the skills documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->