### PR TITLE
Add skill: vistoya/vistoya

### DIFF
--- a/categories/shopping-and-e-commerce.md
+++ b/categories/shopping-and-e-commerce.md
@@ -49,3 +49,4 @@
 - [tradekix](https://clawskills.sh/skills/jamesjohnfox-tradekix) - Query financial market data via the Tradekix API — stock prices, crypto, forex, indices, market news, earnings.
 - [turnip-prophet](https://clawskills.sh/skills/nicholasjackson-turnip-prophet) - Predict Animal Crossing New Horizons turnip prices using the game's exact algorithm.
 - [whop-cli](https://clawskills.sh/skills/g9pedro-whop-cli) - Manage Whop digital products store — create products, plans, track payments, manage memberships.
+- [vistoya](https://clawhub.ai/vistoya/vistoya-fashion) - search engine for fashion/apparel discovery/shopping based on semantic or structured filter.


### PR DESCRIPTION
https://clawhub.ai/vistoya/vistoya-fashion

Adds the vistoya skill to the ecom and shopping category. Vistoya is a tool for browsing embedded RAG of products avaliable on the internet - think google shopping but ai native - fashion oriented(better visual semantic search)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new "vistoya" skill to the Shopping & E-commerce catalog, expanding it to 52 items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->