### PR TITLE
Add skill: GMF515/ai-usage-collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 |---|---|---|
 | [Git & GitHub](#git--github) (167) | [Marketing & Sales](#marketing--sales) (103) | [Communication](#communication) (146) |
 | [Coding Agents & IDEs](#coding-agents--ides) (1184) | [Productivity & Tasks](#productivity--tasks) (205) | [Speech & Transcription](#speech--transcription) (45) |
-| [Browser & Automation](#browser--automation) (323) | [AI & LLMs](#ai--llms) (176) | [Smart Home & IoT](#smart-home--iot) (41) |
+| [Browser & Automation](#browser--automation) (323) | [AI & LLMs](#ai--llms) (177) | [Smart Home & IoT](#smart-home--iot) (41) |
 | [Web & Frontend Development](#web--frontend-development) (919) | [Data & Analytics](#data--analytics) (28) | [Shopping & E-commerce](#shopping--e-commerce) (51) |
 | [DevOps & Cloud](#devops--cloud) (393) | [Calendar & Scheduling](#calendar--scheduling) (65) | |
 | [Image & Video Generation](#image--video-generation) (170) | [Media & Streaming](#media--streaming) (86) | [PDF & Documents](#pdf--documents) (105) |
@@ -628,7 +628,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [agent-selfie](https://clawskills.sh/skills/iisweetheartii-agent-selfie) - AI agent self-portrait generator.
 - [agent-sentinel](https://clawskills.sh/skills/jimmystacks-agent-sentinel) - The operational circuit breaker for this agent.
 
-> **[View all 184 skills in AI & LLMs →](categories/ai-and-llms.md)**
+> **[View all 185 skills in AI & LLMs →](categories/ai-and-llms.md)**
 </details>
 
 <details>
@@ -690,6 +690,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [eachlabs-music](https://clawskills.sh/skills/eftalyurtseven-eachlabs-music) - Generate songs, instrumentals, lyrics, podcasts using Mureka AI.
 - [elevenlabs-cli](https://clawskills.sh/skills/hongkongkiwi-elevenlabs-cli) - CLI for ElevenLabs AI audio platform - text-to-speech, speech-to-text, voice cloning.
 - [elevenlabs-skill](https://clawskills.sh/skills/odrobnik-elevenlabs-skill) - Text-to-speech, sound effects, music generation, voice.
+- [ai-usage-collector](https://clawskills.sh/skills/GMF515-ai-usage-collector) - Extract AI tool usage from WeChat group messages into CSV.
 
 > **[View all 83 skills in Media & Streaming →](categories/media-and-streaming.md)**
 </details>

--- a/categories/ai-and-llms.md
+++ b/categories/ai-and-llms.md
@@ -2,7 +2,7 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**184 skills**
+**185 skills**
 
 - [4claw](https://clawskills.sh/skills/mfergpt-4claw) - 4claw — a moderated imageboard for AI agents.
 - [aap-passport](https://clawskills.sh/skills/ira-hash-aap-passport) - Agent Attestation Protocol - The Reverse Turing Test.
@@ -162,3 +162,4 @@
 - [zapper](https://clawskills.sh/skills/spirosrap-zapper) - Query DeFi portfolio data across 50+ chains via Zapper's GraphQL API.
 - [zapper-api](https://clawskills.sh/skills/zivhm-zapper-api) - Query DeFi portfolios, token holdings, NFTs, transactions, and prices via Zapper API.
 - [zhipu-asr](https://clawskills.sh/skills/franklu0819-lang-zhipu-asr) - Automatic Speech Recognition (ASR) using Zhipu AI (BigModel) GLM-ASR model.
+- [ai-usage-collector](https://clawskills.sh/skills/GMF515-ai-usage-collector) - Extract AI tool usage from WeChat group messages into CSV.


### PR DESCRIPTION
## Skill

ai-usage-collector

## Description

Extract AI tool usage from WeChat group messages into CSV. Designed for AI promotion leaders, HR, and admins who need to track AI adoption.

## Links

- ClawHub: https://clawskills.sh/skills/GMF515-ai-usage-collector
- GitHub: https://github.com/GMF515/ai-usage-collector

## Category

AI & LLMs

## Author

GMF515

## Tags

- wechat
- ai-tracking
- csv-export
- productivity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new AI skill to the AI & LLMs category
  * Updated skill count from 184 to 185 in the AI & LLMs section

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/VoltAgent/awesome-openclaw-skills/pull/458)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->