### PR TITLE
Add Parley

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 | | | |
 |---|---|---|
 | [Git & GitHub](#git--github) (167) | [Marketing & Sales](#marketing--sales) (103) | [Communication](#communication) (146) |
-| [Coding Agents & IDEs](#coding-agents--ides) (1184) | [Productivity & Tasks](#productivity--tasks) (205) | [Speech & Transcription](#speech--transcription) (46) |
+| [Coding Agents & IDEs](#coding-agents--ides) (1184) | [Productivity & Tasks](#productivity--tasks) (206) | [Speech & Transcription](#speech--transcription) (46) |
 | [Browser & Automation](#browser--automation) (323) | [AI & LLMs](#ai--llms) (176) | [Smart Home & IoT](#smart-home--iot) (41) |
 | [Web & Frontend Development](#web--frontend-development) (919) | [Data & Analytics](#data--analytics) (28) | [Shopping & E-commerce](#shopping--e-commerce) (51) |
 | [DevOps & Cloud](#devops--cloud) (393) | [Calendar & Scheduling](#calendar--scheduling) (66) | |
@@ -600,7 +600,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [atlassian-mcp](https://clawskills.sh/skills/atakanermis-atlassian-mcp) - Run the Model Context Protocol (MCP) Atlassian server.
 - [boss-ai-agent](https://github.com/openclaw/skills/tree/main/skills/tonypk/boss-ai-agent/SKILL.md) - AI management middleware with 14 mentors and 9 culture packs.
 
-> **[View all 205 skills in Productivity & Tasks →](categories/productivity-and-tasks.md)**
+> **[View all 206 skills in Productivity & Tasks →](categories/productivity-and-tasks.md)**
 
 </details>
 

--- a/categories/productivity-and-tasks.md
+++ b/categories/productivity-and-tasks.md
@@ -2,7 +2,7 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**205 skills**
+**206 skills**
 
 - [4to1-planner](https://clawskills.sh/skills/qingxuantang-4to1-planner) - AI planning coach using the 4To1 Method™ — turn 4-year vision into daily action.
 - [4todo](https://clawskills.sh/skills/blackstorm-4todo) - Manage 4todo (4to.do) from chat.
@@ -137,6 +137,7 @@
 - [openburn](https://clawskills.sh/skills/logesh2496-openburn) - Automates collecting Pump.fun creator fees, buying tokens with collected SOL, and burning those tokens (buyback.
 - [ops-hygiene](https://clawskills.sh/skills/staybased-ops-hygiene) - Standard operating procedures for agent maintenance, security hygiene, and system health.
 - [paypilot-agms](https://clawskills.sh/skills/agmsyumet-paypilot-agms) - Process payments, send invoices, issue refunds, and manage transactions via a secure payment gateway proxy.
+- [parley](https://clawhub.ai/plugins/@nkuhanas/parley) - Durable coordination state and recovery for multi-agent OpenClaw work.
 - [personal-plans](https://clawskills.sh/skills/gekacross-personal-plans) - Acts as the user's personal planning assistant in the Plans topic.
 - [pinchwork](https://clawskills.sh/skills/anneschuth-pinchwork) - Delegate tasks to other agents.
 - [pipx-desktop-agent](https://clawskills.sh/skills/chillybean-pipx-desktop-agent) - Control mouse, keyboard, and screen for desktop automation tasks.


### PR DESCRIPTION
Adds Parley, a ClawHub plugin for durable coordination state, obligations, plans, artifacts, scoped identity, and recovery across long-running OpenClaw agent work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new skill "parley" to the Productivity & Tasks category, bringing the total available skills to 206.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/VoltAgent/awesome-openclaw-skills/pull/459?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->