### PR TITLE
Add nature-paper-hub: full-pipeline Nature-series journal writing agent

### DIFF
--- a/categories/search-and-research.md
+++ b/categories/search-and-research.md
@@ -2,7 +2,7 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**353 skills**
+**354 skills**
 
 - [1](https://clawskills.sh/skills/nastrology-1) - Personal knowledge base powered by Ensue for capturing and retrieving.
 - [academic-deep-research](https://clawskills.sh/skills/kesslerio-academic-deep-research) - Transparent, rigorous research with full.

--- a/categories/search-and-research.md
+++ b/categories/search-and-research.md
@@ -219,6 +219,7 @@
 - [muninn](https://clawskills.sh/skills/endgegnerbert-tech-muninn) - Universal Context Protocol (CXP) for AI agents. v2.3.7 includes the latest high-performance CXP engine (compiled.
 - [muninn-memory](https://clawskills.sh/skills/phillipneho-muninn-memory) - Memory system for AI agents.
 - [mycroft](https://clawskills.sh/skills/fabe-mycroft) - EPUB and ebook ingestion, local vector index, and Q&A CLI for books.
+- [nature-paper-hub](https://clawhub.ai/Yang1Bai/nature-paper-hub) - Full-pipeline AI writing agent for Nature-series journals (12 journals). Covers journal selection, manuscript drafting, figure generation (CSV→PDF), CrossRef citation verification, LaTeX/Word/PPT export, bilingual paper reader, and reviewer response. Includes 534-paper curated literature index.
 - [nadfunagent](https://clawskills.sh/skills/encipher88-nadfunagent) - Autonomous trading agent for Nad.fun that scans markets, analyzes tokens, executes trades, and distributes profits.
 - [native-typeform](https://clawskills.sh/skills/codeninja23-native-typeform) - Read Typeform forms and responses directly via the Typeform API.
 - [naver-shopping](https://clawskills.sh/skills/dryoo-naver-shopping) - Search for products on Naver Shopping.


### PR DESCRIPTION
## New skill: nature-paper-hub

**ClawHub:** https://clawhub.ai/Yang1Bai/nature-paper-hub  
**GitHub:** https://github.com/Yang1Bai/nature-paper-hub

Full-pipeline AI writing agent for Nature-series journal manuscript preparation. Supports 12 Nature journals with real per-journal specs. Features: journal selection, literature review, figure generation from CSV/Excel, CrossRef citation verification, RetractionWatch retraction check, LaTeX/Word/PPT export, bilingual paper reader, reviewer response with triage. Includes 534-paper curated literature index. Compatible with OpenClaw, Claude Code, and Codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Skill count updated to 354.
  * Added "nature-paper-hub" research skill with a ClawHub link, supporting full manuscript/figure/citation workflows and a curated literature index.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/VoltAgent/awesome-openclaw-skills/pull/461?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->