### PR TITLE
Add LDM outbound deliverability skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,6 +563,8 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [brand-guidelines](https://clawskills.sh/skills/seanphan-brand-guidelines) - Applies Anthropic's official brand colors and typography.
 - [brand-voice-profile](https://clawskills.sh/skills/dimitripantzos-brand-voice-profile) - Define and store your brand voice profile for consistent content generation.
 - [brevo](https://clawskills.sh/skills/yujesyoga-brevo) - Brevo (formerly Sendinblue) email marketing API for managing contacts, lists,.
+- [ldm-openclaw-skill](https://clawhub.ai/live-direct-marketing/ldm-openclaw-skill) - Pre-send deliverability checks for outbound agents.
+- [ldm-openclaw-inbox-mcp-skill](https://clawhub.ai/live-direct-marketing/ldm-openclaw-inbox-mcp-skill) - Paid MCP inbox-placement checks for outbound agents.
 - [socialecho-social-media-management-agent](https://github.com/openclaw/skills/tree/main/skills/socialecho-net/socialecho-social-media-management-agent/SKILL.md) - SocialEcho API team account article report queries.
 - [postiz](https://github.com/openclaw/skills/tree/main/skills/nevo-david/postiz/SKILL.md) - Schedule social media posts and threads across 28+ platforms.
 > **[View all 104 skills in Marketing & Sales →](categories/marketing-and-sales.md)**

--- a/categories/marketing-and-sales.md
+++ b/categories/marketing-and-sales.md
@@ -102,3 +102,5 @@
 - [workcrm](https://clawskills.sh/skills/extraterrest-workcrm) - A lightweight, local-first CRM with an explicit confirmation gate.
 - [writing-assistant](https://clawskills.sh/skills/urrrich-writing-assistant) - You are a Writing Team Lead managing specialized writers via MCP tools.
 - [writing-group-leader](https://clawskills.sh/skills/urrrich-writing-group-leader) - You are a Writing Team Lead managing specialized writers via MCP tools.
+- [ldm-openclaw-skill](https://clawhub.ai/live-direct-marketing/ldm-openclaw-skill) - Pre-send deliverability checks for outbound agents.
+- [ldm-openclaw-inbox-mcp-skill](https://clawhub.ai/live-direct-marketing/ldm-openclaw-inbox-mcp-skill) - Paid MCP inbox-placement checks for outbound agents.


### PR DESCRIPTION
Adds two ClawHub-published OpenClaw skills for outbound deliverability workflows under Marketing & Sales.\n\nClawHub links:\n- https://clawhub.ai/live-direct-marketing/ldm-openclaw-skill\n- https://clawhub.ai/live-direct-marketing/ldm-openclaw-inbox-mcp-skill\n\nGitHub links:\n- https://github.com/live-direct-marketing/ldm-openclaw-skill\n- https://github.com/live-direct-marketing/ldm-openclaw-inbox-mcp-skill\n\nBoth are published in ClawHub as @live-direct-marketing and currently show Moderation: CLEAN. Note: the CONTRIBUTING file mentions github.com/openclaw/skills, but that repository was not resolvable from GitHub; these entries use the live ClawHub pages instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced the Marketing & Sales skills directory with two new features supporting outbound communication: automated pre-send deliverability checks to verify message delivery and premium inbox-placement validation to ensure optimal inbox placement. These capabilities enable marketing teams to improve message quality assurance and delivery success rates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->