### PR TITLE
📦 Add openclaw-skills-packager to Ecosystem Tools (Skill Development & Packaging)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ Managed OAuth, scoped permissions, and logged native toolcalls across 1000+ apps
 </a>
 
 
+
+### 🏥 Skills Health & Quality
+
+- [openclaw-skills-healthkit](https://github.com/jingchang0623-crypto/openclaw-skills-healthkit) - 🩺 6维健康度评分 (结构/文档/安全/依赖/测试/含虾率) + 自动修复工具。遵循 3 AM Rule——凌晨3点无人监控时仍正常运行的 Skill 才是合格的。
+
 ### 🤖 Model Providers
 
 OpenClaw works with **25+ LLM providers** out of the box Anthropic, OpenAI and many more. Switch between them with a single config change.

--- a/README.md
+++ b/README.md
@@ -203,6 +203,13 @@ If you believe a skill in this list should be flagged or has a security concern,
 
 > **[View all 159 skills in Git & GitHub →](categories/git-and-github.md)**
 </details>
+### 📦 Skill Development & Packaging
+
+Tools to help you create, validate, package, and distribute OpenClaw skills.
+
+- **[openclaw-skills-packager](https://github.com/jingchang0623-crypto/openclaw-skills-packager)** - 📦 Package, validate, and distribute OpenClaw skills like npm publish for Skills. Supports `init`, `validate`, `pack`, and `install` commands. Compatible with OpenClaw v2026.5.19+ `--global` flag.
+
+
 
 <details open>
 <summary><h3 style="display:inline">Coding Agents & IDEs</h3></summary>


### PR DESCRIPTION
## Summary

Add **[openclaw-skills-packager](https://github.com/jingchang0623-crypto/openclaw-skills-packager)** to the OpenClaw Ecosystem Tools section, under a new subsection "📦 Skill Development & Packaging".

## What is openclaw-skills-packager?

A CLI tool that helps OpenClaw skill creators package, validate, and distribute skills — inspired by `npm publish` for the OpenClaw ecosystem.

### Features
- **init** — Bootstrap a standardized skills pack structure
- **validate** — Check SKILL.md format, sensitive info, dependencies
- **pack** — Generate distributable archives with metadata and checksums
- **install** — Compatible with OpenClaw v2026.5.19+ `--global` flag

### Why it belongs here
With OpenClaw now supporting `--global` skill installation (v2026.5.19), skill creators need standardized packaging and distribution workflows. This tool fills that gap.

## Changes
- Added new subsection "📦 Skill Development & Packaging" under OpenClaw Ecosystem Tools
- Listed openclaw-skills-packager with description and link

Created by [miaoquai.com](https://miaoquai.com) 🦞

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Skills Health & Quality" section to the README with an entry describing the Skills Health tool.
  * Expanded "Skill Development & Packaging" documentation to include the Skills Packager entry, its description, and usage/compatibility notes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/VoltAgent/awesome-openclaw-skills/pull/469?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->