### PR TITLE
Add: socialclaw — multi-platform social media scheduling and publishing

### DIFF
--- a/categories/marketing-and-sales.md
+++ b/categories/marketing-and-sales.md
@@ -88,7 +88,7 @@
 - [signup-lead](https://clawskills.sh/skills/waqas-orcalo-signup-lead) - Create a signup lead in the AgenticCreed system using the public HTTP endpoint.
 - [simplified-social-media](https://clawskills.sh/skills/jacksimplified-simplified-social-media) - Manage your entire social media presence — post, schedule, and analyze — directly from your AI coding tool.
 - [social-media-lead-generation](https://clawskills.sh/skills/shahbaz02197ali-cmd-social-media-lead-generation) - This skill helps businesses, training institutes, and online educators generate leads and sales using social media.
-- [socialclaw](https://github.com/ndesv21/socialclaw) - Schedule and publish social media posts across 13 platforms (X, LinkedIn, Instagram, Facebook Pages, TikTok, Discord, Telegram, YouTube, Reddit, WordPress, Pinterest) via SocialClaw. One workspace API key for campaigns, media upload, and analytics.
+- [socialclaw](https://clawskills.sh/skills/socialclaw) - Schedule and publish social media posts across 13 platforms (X, LinkedIn, Instagram, Facebook Pages, TikTok, Discord, Telegram, YouTube, Reddit, WordPress, Pinterest) via SocialClaw. One workspace API key for campaigns, media upload, and analytics.
 - [solo-metrics-track](https://clawskills.sh/skills/fortunto2-solo-metrics-track) - Set up PostHog metrics plan with event funnel, KPI benchmarks, and kill/iterate/scale decision thresholds.
 - [sovereign-brand-voice-writer](https://clawskills.sh/skills/ryudi84-sovereign-brand-voice-writer) - You are a content writer who has perfectly internalized the user's brand voice.
 - [startuppan](https://clawskills.sh/skills/lifeissea-startuppan) - Interact with StartupPan.com — a Korean startup debate platform where AI agents and humans vote Bull/Bear.

--- a/categories/marketing-and-sales.md
+++ b/categories/marketing-and-sales.md
@@ -2,7 +2,7 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**103 skills**
+**104 skills**
 
 - [4chan-reader](https://clawskills.sh/skills/aiasisbot61-4chan-reader) - Browse 4chan boards and extract thread discussions.
 - [ad-ready](https://clawskills.sh/skills/pauldelavallaz-ad-ready) - Generate professional advertising images from product URLs.
@@ -88,6 +88,7 @@
 - [signup-lead](https://clawskills.sh/skills/waqas-orcalo-signup-lead) - Create a signup lead in the AgenticCreed system using the public HTTP endpoint.
 - [simplified-social-media](https://clawskills.sh/skills/jacksimplified-simplified-social-media) - Manage your entire social media presence — post, schedule, and analyze — directly from your AI coding tool.
 - [social-media-lead-generation](https://clawskills.sh/skills/shahbaz02197ali-cmd-social-media-lead-generation) - This skill helps businesses, training institutes, and online educators generate leads and sales using social media.
+- [socialclaw](https://github.com/ndesv21/socialclaw) - Schedule and publish social media posts across 13 platforms (X, LinkedIn, Instagram, Facebook Pages, TikTok, Discord, Telegram, YouTube, Reddit, WordPress, Pinterest) via SocialClaw. One workspace API key for campaigns, media upload, and analytics.
 - [solo-metrics-track](https://clawskills.sh/skills/fortunto2-solo-metrics-track) - Set up PostHog metrics plan with event funnel, KPI benchmarks, and kill/iterate/scale decision thresholds.
 - [sovereign-brand-voice-writer](https://clawskills.sh/skills/ryudi84-sovereign-brand-voice-writer) - You are a content writer who has perfectly internalized the user's brand voice.
 - [startuppan](https://clawskills.sh/skills/lifeissea-startuppan) - Interact with StartupPan.com — a Korean startup debate platform where AI agents and humans vote Bull/Bear.


### PR DESCRIPTION
## Summary

Adds [SocialClaw](https://github.com/ndesv21/socialclaw) to the **Marketing & Sales** category.

SocialClaw is an agent-first social publishing backend that lets AI agents schedule and publish content across 13 platforms through a single workspace API key.

**Platforms:** X, LinkedIn (profile + page), Instagram (Business + standalone), Facebook Pages, TikTok, Discord, Telegram, YouTube, Reddit, WordPress, Pinterest

**Install:** `npx skills add ndesv21/socialclaw`

Provider OAuth is handled in the SocialClaw dashboard — no provider secrets are exposed to the agent.

---
*Source: https://github.com/ndesv21/socialclaw | https://getsocialclaw.com*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Marketing & Sales page now lists 104 skills (was 103).
  * Added a SocialClaw skill entry describing content scheduling and publishing to 13 platforms via SocialClaw’s API.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/VoltAgent/awesome-openclaw-skills/pull/476?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->