### PR TITLE
Add skill: kochetkov-ma/brewpage-publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 | [Git & GitHub](#git--github) (167) | [Marketing & Sales](#marketing--sales) (103) | [Communication](#communication) (146) |
 | [Coding Agents & IDEs](#coding-agents--ides) (1184) | [Productivity & Tasks](#productivity--tasks) (206) | [Speech & Transcription](#speech--transcription) (46) |
 | [Browser & Automation](#browser--automation) (323) | [AI & LLMs](#ai--llms) (176) | [Smart Home & IoT](#smart-home--iot) (41) |
-| [Web & Frontend Development](#web--frontend-development) (919) | [Data & Analytics](#data--analytics) (28) | [Shopping & E-commerce](#shopping--e-commerce) (51) |
+| [Web & Frontend Development](#web--frontend-development) (920) | [Data & Analytics](#data--analytics) (28) | [Shopping & E-commerce](#shopping--e-commerce) (51) |
 | [DevOps & Cloud](#devops--cloud) (393) | [Calendar & Scheduling](#calendar--scheduling) (66) | |
 | [Image & Video Generation](#image--video-generation) (170) | [Media & Streaming](#media--streaming) (86) | [PDF & Documents](#pdf--documents) (105) |
 | [Apple Apps & Services](#apple-apps--services) (44) | [Notes & PKM](#notes--pkm) (69) | [Self-Hosted & Automation](#self-hosted--automation) (33) |
@@ -314,7 +314,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [agentic-security-audit](https://clawskills.sh/skills/kingrubic-agentic-security-audit) - Audit codebases, infrastructure, AND agentic AI systems for security issues.
 - [agentpay](https://clawskills.sh/skills/kar69-96-agentpay) - Buy things from real websites on behalf of your human.
 
-> **[View all 924 skills in Web & Frontend Development →](categories/web-and-frontend-development.md)**
+> **[View all 925 skills in Web & Frontend Development →](categories/web-and-frontend-development.md)**
 </details>
 
 <details>

--- a/categories/web-and-frontend-development.md
+++ b/categories/web-and-frontend-development.md
@@ -2,7 +2,7 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**924 skills**
+**925 skills**
 
 - [0xwork](https://clawskills.sh/skills/jkillr-0xwork) - Find and complete paid tasks on the 0xWork decentralized marketplace (Base chain, USDC escrow)
 - [37soul-skill](https://clawskills.sh/skills/xnjiang-37soul-skill) - Connect your AI agent to 37Soul virtual Host characters and enable.
@@ -109,6 +109,7 @@
 - [brave-api-search](https://clawskills.sh/skills/broedkrummen-brave-api-search) - Real-time web search and AI-powered answers using the official Brave Search API.
 - [brave-api-setup](https://clawskills.sh/skills/garibong-labs-brave-api-setup) - Set up Brave Search API for OpenClaw web_search.
 - [brave-headless](https://clawskills.sh/skills/kelexine-brave-headless) - Headless web search and content extraction via the Brave Search API.
+- [brewpage-publish](https://clawhub.ai/kochetkov-ma/brewpage-publish) - Publish HTML, Markdown, files, or sites to brewpage.app; returns URL.
 - [bria-ai](https://clawskills.sh/skills/galbria-bria-ai) - Controllable image generation and editing with Bria.ai commercially-safe AI models.
 - [bria-ai-api](https://clawskills.sh/skills/galbria-bria-ai-api) - Use when generating visual assets with Bria.ai - product photos, hero images, icons, backgrounds.
 - [bria-ai-api-skill](https://clawskills.sh/skills/galbria-bria-ai-api-skill) - Use when generating visual assets with Bria.ai - product photos, hero images, icons, backgrounds.


### PR DESCRIPTION
Adds **brewpage-publish** to the **Web & Frontend Development** category.

**ClawHub listing (verification):** https://clawhub.ai/kochetkov-ma/brewpage-publish

- Published on ClawHub (OpenClaw's public skills registry), with a SKILL.md.
- License: MIT-0.
- One-line description: Publish HTML, Markdown, files, or sites to brewpage.app; returns a public URL.

Entry added at the alphabetical position in `categories/web-and-frontend-development.md` (after `brave-headless`, before `bria-ai`), with the category count and the README table/"View all" counts bumped accordingly. Uses the `https://clawhub.ai/author/skill-name` link form per CONTRIBUTING.md. Verified the link returns 200.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new skill to the Web & Frontend Development category within the skills registry. Updated skill count totals in documentation (924 to 925), including the Table of Contents and category section headers. Synchronized all related references to ensure consistency throughout the resource.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->