### PR TITLE
Add runapi-mcp to Image & Video Generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 | [Browser & Automation](#browser--automation) (323) | [AI & LLMs](#ai--llms) (176) | [Smart Home & IoT](#smart-home--iot) (41) |
 | [Web & Frontend Development](#web--frontend-development) (919) | [Data & Analytics](#data--analytics) (28) | [Shopping & E-commerce](#shopping--e-commerce) (51) |
 | [DevOps & Cloud](#devops--cloud) (393) | [Calendar & Scheduling](#calendar--scheduling) (66) | |
-| [Image & Video Generation](#image--video-generation) (170) | [Media & Streaming](#media--streaming) (86) | [PDF & Documents](#pdf--documents) (105) |
+| [Image & Video Generation](#image--video-generation) (171) | [Media & Streaming](#media--streaming) (86) | [PDF & Documents](#pdf--documents) (105) |
 | [Apple Apps & Services](#apple-apps--services) (44) | [Notes & PKM](#notes--pkm) (69) | [Self-Hosted & Automation](#self-hosted--automation) (33) |
 | [Search & Research](#search--research) (345) | [iOS & macOS Development](#ios--macos-development) (29) | [Security & Passwords](#security--passwords) (54) |
 | [Clawdbot Tools](#clawdbot-tools) (37) | [Transportation](#transportation) (110) | [Moltbook](#moltbook) (29) |
@@ -384,7 +384,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [skywork-design](https://clawskills.sh/skills/gxcun17-skywork-design) - Generate and edit images via Skywork Image for posters, logos and more.
 
 - [ai-video-remix](https://clawskills.sh/skills/abu-shotai-ai-video-remix) - AI-driven video remix from local library using ShotAI.
-> **[View all 170 skills in Image & Video Generation →](categories/image-and-video-generation.md)**
+> **[View all 171 skills in Image & Video Generation →](categories/image-and-video-generation.md)**
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [cad-agent](https://clawskills.sh/skills/clawd-maf-cad-agent) - Rendering server for AI agents doing CAD work.
 - [calorie-visualizer](https://clawskills.sh/skills/vintlin-calorie-visualizer) - Local calorie logging and visual reporting (auto-refreshes and returns report image after each log)
 - [canva-connect](https://clawskills.sh/skills/coolmanns-canva-connect) - Manage Canva designs, assets, and folders via the Connect API.
+- [runapi-mcp](https://github.com/runapi-ai/mcp) - 130+ AI models for image, video, music, audio, and LLM generation from 18 providers. 8 MCP tools: browse models, check pricing, create tasks, poll results, check balance, and call LLM endpoints. Free catalog tools work without API key. `npx @runapi.ai/mcp`
 - [skywork-design](https://clawskills.sh/skills/gxcun17-skywork-design) - Generate and edit images via Skywork Image for posters, logos and more.
 
 - [ai-video-remix](https://clawskills.sh/skills/abu-shotai-ai-video-remix) - AI-driven video remix from local library using ShotAI.


### PR DESCRIPTION
## Add RunAPI MCP to Image & Video Generation

**[runapi-mcp](https://github.com/runapi-ai/mcp)** — 130+ AI models for image, video, music, audio, and LLM generation from 18 providers (Flux, Kling, Seedance, Veo, Suno, ElevenLabs, Claude, GPT, Gemini). 8 MCP tools with free catalog browsing. Published on npm as `@runapi.ai/mcp`.

### Key facts
- 8 MCP tools (4 free, 4 require API key)
- 130+ models across 5 modalities
- npm: [@runapi.ai/mcp](https://www.npmjs.com/package/@runapi.ai/mcp)
- GitHub: [runapi-ai/mcp](https://github.com/runapi-ai/mcp)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added "runapi-mcp" to the Image & Video Generation list (130+ model catalog, 8 MCP tools; some catalog tools work without an API key) and included the npx install command.
  * Updated Table of Contents and the "View all … skills" count from 170 to 171 to reflect the new entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->