### PR TITLE
Add runapi-mcp to Image & Video Generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [cad-agent](https://clawskills.sh/skills/clawd-maf-cad-agent) - Rendering server for AI agents doing CAD work.
 - [calorie-visualizer](https://clawskills.sh/skills/vintlin-calorie-visualizer) - Local calorie logging and visual reporting (auto-refreshes and returns report image after each log)
 - [canva-connect](https://clawskills.sh/skills/coolmanns-canva-connect) - Manage Canva designs, assets, and folders via the Connect API.
+- [runapi-mcp](https://clawhub.ai/runapi-ai/runapi-mcp) - 130+ AI models for image, video, music, audio, and LLM generation from 18 providers. 8 MCP tools with free catalog browsing. `npx @runapi.ai/mcp`
 - [skywork-design](https://clawskills.sh/skills/gxcun17-skywork-design) - Generate and edit images via Skywork Image for posters, logos and more.
 
 - [ai-video-remix](https://clawskills.sh/skills/abu-shotai-ai-video-remix) - AI-driven video remix from local library using ShotAI.

--- a/categories/image-and-video-generation.md
+++ b/categories/image-and-video-generation.md
@@ -143,6 +143,7 @@
 - [saa-agent](https://clawskills.sh/skills/mirabarukaso-saa-agent) - Enables AI agents to generate images using the Character Select Stand Alone App (SAA) image generation backend.
 - [shopify-bulk-upload](https://clawskills.sh/skills/zhaoteng-qd-shopify-bulk-upload) - Bulk upload products to Shopify stores.
 - [skill-1](https://clawskills.sh/skills/claudiodrusus-skill-1) - Generate QR codes from text, URLs, WiFi credentials, vCards, or any data.
+- [runapi-mcp](https://clawhub.ai/runapi-ai/runapi-mcp) - 130+ AI models for image, video, music, audio, and LLM generation from 18 providers. 8 MCP tools with free catalog browsing. `npx @runapi.ai/mcp`
 - [skywork-design](https://clawskills.sh/skills/gxcun17-skywork-design) - Generate and edit images via Skywork Image for posters, logos and more.
 - [snapog](https://clawskills.sh/skills/beameasy-snapog) - Generate social images and OG cards from professional templates via the SnapOG API.
 - [solo-humanize](https://clawskills.sh/skills/fortunto2-solo-humanize) - Strip AI writing patterns from text — em dashes, stock phrases, promotional inflation, performed authenticity.


### PR DESCRIPTION
Adds [runapi-mcp](https://clawhub.ai/runapi-ai/runapi-mcp) to the Image & Video Generation category.

**ClawHub:** https://clawhub.ai/runapi-ai/runapi-mcp

130+ AI models for image, video, music, audio, and LLM generation from 18 providers. 8 MCP tools with free catalog browsing.

Resubmitting after #485 — apologies for the stale base and missing category file update in the previous PR. This one is rebased on latest main and includes both README and category file entries. ClawHub listing: https://clawhub.ai/runapi-ai/runapi-mcp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `runapi-mcp` to the Image & Video Generation skills list, available via `npx `@runapi.ai/mcp``.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->