### PR TITLE
Add TempGuru event staffing to Productivity & Tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1040,7 +1040,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [gog](https://clawskills.sh/skills/steipete-gog) - Google Workspace CLI for Gmail, Calendar, Drive, Contacts, Sheets, and Docs.
 - [google-calendar](https://clawskills.sh/skills/adrianmiller99-google-calendar) - Interact with Google Calendar via the Google Calendar.
 
-> **[View all 66 skills in Calendar & Scheduling →](categories/calendar-and-scheduling.md)**
+> **[View all 67 skills in Calendar & Scheduling →](categories/calendar-and-scheduling.md)**
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -1028,6 +1028,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [cron-scheduling](https://clawskills.sh/skills/gitgoodordietrying-cron-scheduling) - Schedule and manage recurring tasks with cron.
 - [dharma-ai](https://clawskills.sh/skills/jigaraero-dharma-ai) - Apply ancient Hindu ethical frameworks from the Ramayana and Mahabharata as behavioral principles for AI agents.
 - [doc-accurate-codegen](https://clawskills.sh/skills/tobisamaa-doc-accurate-codegen) - Generate code that references actual documentation, preventing hallucination bugs.
+- [tempguru-event-staffing-ordering](https://clawskills.sh/skills/kissmyabs32-tempguru-event-staffing-ordering) - Order W-2 compliant temporary event staff for conventions, trade shows, festivals, concerts, and brand activations across 300+ US/CA markets. Live MCP tools for city coverage, roles, rates, and compliance.
 - [event-watcher](https://clawskills.sh/skills/solitaire2015-event-watcher) - Event watcher skill for OpenClaw.
 - [farmos-equipment](https://clawskills.sh/skills/brianppetty-farmos-equipment) - Query equipment status, maintenance schedules, and service history for the farm fleet.
 - [fastmail](https://clawskills.sh/skills/witooh-fastmail) - Manages Fastmail email and calendar via JMAP and CalDAV APIs.

--- a/README.md
+++ b/README.md
@@ -1028,7 +1028,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [cron-scheduling](https://clawskills.sh/skills/gitgoodordietrying-cron-scheduling) - Schedule and manage recurring tasks with cron.
 - [dharma-ai](https://clawskills.sh/skills/jigaraero-dharma-ai) - Apply ancient Hindu ethical frameworks from the Ramayana and Mahabharata as behavioral principles for AI agents.
 - [doc-accurate-codegen](https://clawskills.sh/skills/tobisamaa-doc-accurate-codegen) - Generate code that references actual documentation, preventing hallucination bugs.
-- [tempguru-event-staffing-ordering](https://clawskills.sh/skills/kissmyabs32-tempguru-event-staffing-ordering) - Order W-2 compliant temporary event staff for conventions, trade shows, festivals, concerts, and brand activations across 300+ US/CA markets. Live MCP tools for city coverage, roles, rates, and compliance.
+- [tempguru-event-staffing-ordering](https://clawskills.sh/skills/kissmyabs32-tempguru-event-staffing-ordering) - Order W-2 compliant temporary event staff for conventions, trade shows, festivals, concerts, and brand activations across 300+ US/CA markets. Live MCP tools for city coverage, roles, rates, and compliance, plus an opt-in request_quote submission.
 - [event-watcher](https://clawskills.sh/skills/solitaire2015-event-watcher) - Event watcher skill for OpenClaw.
 - [farmos-equipment](https://clawskills.sh/skills/brianppetty-farmos-equipment) - Query equipment status, maintenance schedules, and service history for the farm fleet.
 - [fastmail](https://clawskills.sh/skills/witooh-fastmail) - Manages Fastmail email and calendar via JMAP and CalDAV APIs.


### PR DESCRIPTION
Adds TempGuru event staffing ordering skill to the Productivity & Tasks section. Orders W-2 compliant event staff for conventions, trade shows, festivals, and brand activations across 300+ US/CA markets with live MCP tools for coverage, rates, and compliance. ClawHub listing live at kissmyabs32/tempguru-event-staffing-ordering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Calendar & Scheduling skill entry for temporary event staffing ordering, describing W-2 compliant staffing across 300+ US/CA markets, live MCP tools, role selection, rate management, and compliance tracking.
  * Updated the "View all … skills in Calendar & Scheduling" listing count from 66 to 67.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->