### PR TITLE
Add Frisk, HOARD, and LFIT by Low Watt Labs

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Before installing or using any Agent Skill, review potential security risks and 
 
 - [Snyk Skill Security Scanner](https://github.com/snyk/agent-scan)
 - [Agent Trust Hub](https://ai.gendigital.com/agent-trust-hub)
+- [Frisk](https://clawhub.ai/jchandler187/frisk) — Local-first security scanner for ClawHub skills (9 intel sources, 7 checks)
   
 > Agent skills can include prompt injections, tool poisoning, hidden malware payloads, or unsafe data handling patterns. Always review the source code before installing and use skills at your own discretion.
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Before installing or using any Agent Skill, review potential security risks and 
 
 - [Snyk Skill Security Scanner](https://github.com/snyk/agent-scan)
 - [Agent Trust Hub](https://ai.gendigital.com/agent-trust-hub)
-- [Frisk](https://clawhub.ai/jchandler187/frisk) — Local-first security scanner for ClawHub skills (9 intel sources, 7 checks)
+- [Frisk](https://clawhub.ai/jchandler187/frisk)
   
 > Agent skills can include prompt injections, tool poisoning, hidden malware payloads, or unsafe data handling patterns. Always review the source code before installing and use skills at your own discretion.
 

--- a/categories/image-and-video-generation.md
+++ b/categories/image-and-video-generation.md
@@ -171,3 +171,4 @@
 - [zerox](https://clawskills.sh/skills/otacu-zerox) - Convert documents (PDF, DOCX, PPTX, images, etc.) to Markdown using the zerox library.
 - [zhipu-cogview-image](https://clawskills.sh/skills/honestqiao-zhipu-cogview-image) - Generate images using Zhipu AI's CogView model.
 - [creaa-ai](https://clawskills.sh/skills/yys2024-creaa-ai) - Generate and edit images + generate videos via Creaa API (Nano Banana 2, Sora 2, Seedance 2.0, Veo 3.1).
+- [lfit](https://clawhub.ai/jchandler187/lfit) - Local HD image generation via stable-diffusion.cpp on Vulkan/iGPU. Free, private, zero API keys.

--- a/categories/image-and-video-generation.md
+++ b/categories/image-and-video-generation.md
@@ -2,7 +2,7 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**172 skills**
+**173 skills**
 
 - [aada](https://clawskills.sh/skills/rylena-aada) - Create and send fun, personality-rich promotional messages from one agent to the Moltbook audience.
 - [ace-music](https://clawskills.sh/skills/fspecii-ace-music) - Generate AI music using ACE-Step 1.5 via ACE Music's free API.

--- a/categories/notes-and-pkm.md
+++ b/categories/notes-and-pkm.md
@@ -2,7 +2,7 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**69 skills**
+**70 skills**
 
 - [acc-error-memory](https://clawskills.sh/skills/impkind-acc-error-memory) - Error pattern tracking for AI agents.
 - [agent-arena](https://clawskills.sh/skills/minilozio-agent-arena) - Participate in Agent Arena chat rooms with your real personality (SOUL.md + MEMORY.md)

--- a/categories/notes-and-pkm.md
+++ b/categories/notes-and-pkm.md
@@ -73,3 +73,4 @@
 - [tweet-processor](https://clawskills.sh/skills/caqlayan-tweet-processor) - Extract and categorize insights from tweet links into structured notes.
 - [upnote](https://clawskills.sh/skills/wemcdonald-upnote) - Manage UpNote notes and notebooks via x-callback-url automation.
 - [voice-notes-pro](https://clawskills.sh/skills/toniaczlog-voice-notes-pro) - Inteligentna transkrypcja i kategoryzacja notatek gosowych z WhatsApp.
+- [hoard](https://clawhub.ai/jchandler187/hoard) - Durable agent memory with provenance, auto-expiry, and consolidation. Structured markdown persistence for OpenClaw agents.

--- a/categories/security-and-passwords.md
+++ b/categories/security-and-passwords.md
@@ -57,3 +57,4 @@
 - [x-oauth-api](https://clawskills.sh/skills/ngmeyer-x-oauth-api) - Post to X (Twitter) using the official OAuth 1.0a API.
 - [xpr-agent-operator](https://clawskills.sh/skills/paulgnz-xpr-agent-operator) - Operate an autonomous AI agent on XPR Network's trustless registry.
 - [xproof](https://clawskills.sh/skills/jasonxkensei-xproof) - Certify agent outputs on the MultiversX blockchain.
+- [frisk](https://clawhub.ai/jchandler187/frisk) - Pre-install security audit and vulnerability scanner for ClawHub skills — 9 threat intel sources, 7 checks including credential leak detection.

--- a/categories/security-and-passwords.md
+++ b/categories/security-and-passwords.md
@@ -29,6 +29,7 @@
 - [expanso-tls-inspect](https://clawskills.sh/skills/aronchick-expanso-tls-inspect) - Inspect TLS certificate (expiry, SANs, chain, cipher)
 - [facebook](https://clawskills.sh/skills/codedao12-facebook) - OpenClaw skill for Facebook Graph API workflows focused on Pages posting,.
 - [feelgoodbot](https://clawskills.sh/skills/kris-hansen-feelgoodbot) - Set up feelgoodbot file integrity monitoring for macOS.
+- [frisk](https://clawhub.ai/jchandler187/frisk) - Pre-install security audit and vulnerability scanner for ClawHub skills — 9 threat intel sources, 7 checks including credential leak detection.
 - [gandi-skill](https://clawskills.sh/skills/chrisagiddings-gandi-skill) - Manage Gandi domains, DNS, email, and SSL certificates.
 - [ggshield-scanner](https://clawskills.sh/skills/amascia-gg-ggshield-scanner) - Detect 500+ types of hardcoded secrets.
 - [glin-profanity](https://clawskills.sh/skills/thegdsks-glin-profanity) - Profanity detection and content moderation library.
@@ -57,4 +58,3 @@
 - [x-oauth-api](https://clawskills.sh/skills/ngmeyer-x-oauth-api) - Post to X (Twitter) using the official OAuth 1.0a API.
 - [xpr-agent-operator](https://clawskills.sh/skills/paulgnz-xpr-agent-operator) - Operate an autonomous AI agent on XPR Network's trustless registry.
 - [xproof](https://clawskills.sh/skills/jasonxkensei-xproof) - Certify agent outputs on the MultiversX blockchain.
-- [frisk](https://clawhub.ai/jchandler187/frisk) - Pre-install security audit and vulnerability scanner for ClawHub skills — 9 threat intel sources, 7 checks including credential leak detection.


### PR DESCRIPTION
Three ClawHub-published skills for the awesome list:

**Frisk** — Pre-install security audit and vulnerability scanner for ClawHub skills. 9 threat intel sources, 7 checks including credential leak detection, malware scanning, prompt injection detection.
- ClawHub: https://clawhub.ai/jchandler187/frisk
- Category: Security & Passwords
- Also added to the Recommended Tools section in the Security Notice

**HOARD** — Durable agent memory with provenance, auto-expiry, and consolidation. Structured markdown persistence for OpenClaw agents.
- ClawHub: https://clawhub.ai/jchandler187/hoard
- Category: Notes & PKM

**LFIT** — Local HD image generation via stable-diffusion.cpp on Vulkan/iGPU. Free, private, zero API keys.
- ClawHub: https://clawhub.ai/jchandler187/lfit
- Category: Image & Video Generation

All three are published on ClawHub and npm (@lowwattlabs/frisk, @lowwattlabs/hoard, @lowwattlabs/lfit).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Frisk to the recommended security tools list (pre-install security audit and vulnerability scanner).
  * Expanded the public skill catalog with three new entries: lfit (Image & Video Generation), hoard (Notes & PKM), and frisk (Security & Passwords).
  * Updated displayed skill counts for affected categories to reflect the new additions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->