### PR TITLE
Add proactive-soul by @bobgourley

### DIFF
--- a/categories/productivity-and-tasks.md
+++ b/categories/productivity-and-tasks.md
@@ -146,6 +146,7 @@
 - [postfast](https://clawskills.sh/skills/peturgeorgievv-postfast) - Schedule and manage social media posts across TikTok, Instagram, Facebook, X (Twitter), YouTube, LinkedIn, Threads.
 - [postqued-api](https://clawskills.sh/skills/syeddhasnainn-postqued-api) - PostQued social media scheduling API integration.
 - [ppt-ooxml-tool](https://clawskills.sh/skills/jason2be-ppt-ooxml-tool) - AI-agent Skill for PPTX OOXML localization workflows.
+- [proactive-soul]([https://clawskills.sh/skills/jason2be-ppt-ooxml-tool) - Gives your agent an inner life — proactive daily dispatches, persistent curiosity threads across sessions, and genuine pushback when it disagrees.
 - [publora](https://clawskills.sh/skills/sergebulaev-publora) - Publora API — schedule and publish social media posts across 10 platforms (X/Twitter, LinkedIn, Instagram, Threads.
 - [publora-mastodon](https://clawskills.sh/skills/sergebulaev-publora-mastodon) - Post or schedule content to Mastodon using the Publora API.
 - [qa-testing-bots](https://clawskills.sh/skills/g4dr-qa-testing-bots) - This skill enables Claude to build and run **automated QA testing bots** that simulate.


### PR DESCRIPTION
Adding proactive-soul — a skill that gives OpenClaw agents an inner life with four typed daily dispatches, persistent CURIOSITY.md threads across sessions, and genuine pushback when the agent disagrees.

ClawHub: https://clawhub.ai/bobgourley/proactive-soul

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new productivity tool to the skills documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->