### PR TITLE
Add skill: kriptoburak/hermes-tweet

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 </div>
   
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
-[![Skills Count](https://img.shields.io/badge/skills-5198-blue?style=flat-square)](#table-of-contents)
+[![Skills Count](https://img.shields.io/badge/skills-5199-blue?style=flat-square)](#table-of-contents)
 [![Last Update](https://img.shields.io/github/last-commit/VoltAgent/awesome-clawdbot-skills?label=Last%20update&style=flat-square)](https://github.com/VoltAgent/awesome-clawdbot-skills/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc)
 <a href="https://github.com/VoltAgent/voltagent">
   <img alt="VoltAgent" src="https://cdn.voltagent.dev/website/logo/logo-2-svg.svg" height="20" />
@@ -195,7 +195,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 | [DevOps & Cloud](#devops--cloud) (393) | [Calendar & Scheduling](#calendar--scheduling) (66) | |
 | [Image & Video Generation](#image--video-generation) (170) | [Media & Streaming](#media--streaming) (86) | [PDF & Documents](#pdf--documents) (105) |
 | [Apple Apps & Services](#apple-apps--services) (44) | [Notes & PKM](#notes--pkm) (69) | [Self-Hosted & Automation](#self-hosted--automation) (33) |
-| [Search & Research](#search--research) (345) | [iOS & macOS Development](#ios--macos-development) (29) | [Security & Passwords](#security--passwords) (54) |
+| [Search & Research](#search--research) (346) | [iOS & macOS Development](#ios--macos-development) (29) | [Security & Passwords](#security--passwords) (54) |
 | [Clawdbot Tools](#clawdbot-tools) (37) | [Transportation](#transportation) (110) | [Moltbook](#moltbook) (29) |
 | [CLI Utilities](#cli-utilities) (180) | [Personal Development](#personal-development) (50) | [Gaming](#gaming) (35) |
 | [Health & Fitness](#health--fitness) (87) | | |
@@ -473,9 +473,10 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [airbnb](https://clawskills.sh/skills/stveenli-airbnb) - Search Airbnb listings with prices, ratings, and direct links.
 - [openclaw-free-web-search](https://clawskills.sh/skills/wd041216-bit-openclaw-free-web-search) - Free, private web search for OpenClaw with self-hosted SearXNG + Scrapling anti-bot + multi-source cross-validation. Zero API keys, zero cost. Tells you how much to trust the answer.
 - [xquik-x-twitter-scraper](https://clawskills.sh/skills/kriptoburak-xquik-x-twitter-scraper) - X API scraper with 40+ tools for AI agents.
+- [hermes-tweet](https://clawhub.ai/kriptoburak/hermes-tweet) - Hermes Agent plugin for X/Twitter read and controlled actions.
 - [skywork-search](https://clawskills.sh/skills/gxcun17-skywork-search) - AI-powered web search for real-time information — retrieve up-to-date content.
 
-> **[View all 352 skills in Search & Research →](categories/search-and-research.md)**
+> **[View all 353 skills in Search & Research →](categories/search-and-research.md)**
 </details>
 
 <details>

--- a/categories/search-and-research.md
+++ b/categories/search-and-research.md
@@ -345,3 +345,4 @@
 - [zynd-network](https://clawskills.sh/skills/atmegabuzz-zynd-network) - Connect to the Zynd AI Network to discover, communicate with, and pay other AI agents.
 - [aminer-open-academic](https://clawskills.sh/skills/canxiangcc-aminer-open-academic) - AMiner open academic resource query tool and academic data acquisition tool.
 - [xquik-x-twitter-scraper](https://clawskills.sh/skills/kriptoburak-xquik-x-twitter-scraper) - X API scraper with 40+ tools for AI agents.
+- [hermes-tweet](https://clawhub.ai/kriptoburak/hermes-tweet) - Hermes Agent plugin for X/Twitter read and controlled actions.


### PR DESCRIPTION
## Summary
- Add Hermes Tweet to the Search & Research category.
- Update the visible Search & Research and total skill counts.

ClawHub: https://clawhub.ai/kriptoburak/hermes-tweet

Hermes Tweet is a Hermes Agent plugin for X/Twitter read workflows and controlled actions through Xquik. The ClawHub page is live, shows Security Audit Pass, and static scan status is clean.

## Validation
- git diff --check
- Added-link checks: https://clawhub.ai/kriptoburak/hermes-tweet and updated badge URL HTTP 200
- Duplicate count check for the Hermes Tweet link in README and Search & Research category
- Added-line hygiene and real secret scan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "hermes-tweet" skill to the Search & Research section, bringing the total skill count to 5199.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->