### PR TITLE
Add skill: bin1874/before-you-build

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [agent-chat-ux-v1-4-0](https://clawskills.sh/skills/maverick-software-agent-chat-ux-v1-4-0) - Multi-agent UX for OpenClaw Control UI — agent selector, per-agent sessions, session history viewer with search.
 - [skywork-ppt](https://clawskills.sh/skills/gxcun17-skywork-ppt) - Generate, imitate, and edit PowerPoint presentations with skywork.
 - [skywork-music-maker](https://clawskills.sh/skills/gxcun17-skywork-music-maker) - Create professional music with Mureka AI.
+- [before-you-build](https://clawhub.ai/bin1874/before-you-build) - Review product risk before building.
 
 > **[View all 1200 skills in Coding Agents & IDEs →](categories/coding-agents-and-ides.md)**
 </details>


### PR DESCRIPTION
## Summary
- Add the published ClawHub listing for `before-you-build` to Coding Agents & IDEs.
- Keep the entry to a single README row, per the contribution guide.

## ClawHub link
https://clawhub.ai/bin1874/before-you-build

## Validation
- Checked upstream `main` before submitting: no existing `before-you-build`, `bin1874`, or ClawHub entry found.
- Checked existing PRs from `bin1874`: no duplicate PR found.
- Ran `git diff --check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new "before-you-build" skill entry to the Coding Agents & IDEs section, helping users review product risk before building.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->