### PR TITLE
Add skill: solvex-top/traffic-standards-kb

### DIFF
--- a/README.md
+++ b/README.md
@@ -817,6 +817,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [camino-journey](https://clawskills.sh/skills/james-southendsolutions-camino-journey) - Plan multi-waypoint journeys with route optimization, feasibility analysis, and time budget constraints.
 - [camino-real-estate](https://clawskills.sh/skills/james-southendsolutions-camino-real-estate) - Evaluate any address for home buyers and renters.
 - [camino-route](https://clawskills.sh/skills/james-southendsolutions-camino-route) - Get detailed routing between two points with distance, duration, and optional turn-by-turn directions.
+- [traffic-standards-kb](https://clawhub.ai/solvex-top/traffic-standards-kb) - Chinese smart transportation standards knowledge base (GB/JT/GA) for writing solutions with industry standard citations.
 
 > **[View all 110 skills in Transportation →](categories/transportation.md)**
 </details>


### PR DESCRIPTION
Adds [traffic-standards-kb](https://clawhub.ai/solvex-top/traffic-standards-kb) — a skill published on ClawHub for querying Chinese transportation standards (GB, JT, GA) via the Solvex API.

ClawHub: https://clawhub.ai/solvex-top/traffic-standards-kb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new Transportation category skill entry featuring a Chinese transportation standards knowledge base, enabling users to reference industry-standard citations in their solutions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->