### PR TITLE
Add skill: amiller/google-service-accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1048,6 +1048,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [gcal-pro](https://clawskills.sh/skills/bilalmohamed187-cpu-gcal-pro) - Google Calendar integration for viewing, creating, and managing.
 - [gog](https://clawskills.sh/skills/steipete-gog) - Google Workspace CLI for Gmail, Calendar, Drive, Contacts, Sheets, and Docs.
 - [google-calendar](https://clawskills.sh/skills/adrianmiller99-google-calendar) - Interact with Google Calendar via the Google Calendar.
+- [google-service-accounts](https://clawhub.ai/amiller/google-service-accounts) - Headless Google Sheets, Docs, Drive, Calendar via service-account sharing.
 
 > **[View all 66 skills in Calendar & Scheduling →](categories/calendar-and-scheduling.md)**
 </details>

--- a/categories/calendar-and-scheduling.md
+++ b/categories/calendar-and-scheduling.md
@@ -33,6 +33,7 @@
 - [gcal-pro](https://clawskills.sh/skills/bilalmohamed187-cpu-gcal-pro) - Google Calendar integration for viewing, creating, and managing.
 - [gog](https://clawskills.sh/skills/steipete-gog) - Google Workspace CLI for Gmail, Calendar, Drive, Contacts, Sheets, and Docs.
 - [google-calendar](https://clawskills.sh/skills/adrianmiller99-google-calendar) - Interact with Google Calendar via the Google Calendar.
+- [google-service-accounts](https://clawhub.ai/amiller/google-service-accounts) - Headless Google Sheets, Docs, Drive, Calendar via service-account sharing.
 - [grazy](https://clawskills.sh/skills/thomyg-grazy) - grazy - Your Grazer Command Line Companion.
 - [greek-financial-statements](https://clawskills.sh/skills/satoshistackalotto-greek-financial-statements) - Greek financial statement generation — P&L, balance sheets, VAT summaries with EGLS integration.
 - [habib-pdf-to-json](https://clawskills.sh/skills/dbmoradi60-habib-pdf-to-json) - Extract structured data from construction PDFs.


### PR DESCRIPTION
ClawHub link: https://clawhub.ai/amiller/google-service-accounts

Adds **google-service-accounts** to Calendar & Scheduling — headless Google Sheets/Docs/Drive/Calendar access via a plain service account: you share the file or calendar with the robot's email instead of standing up an OAuth app. No consent screen, no 7-day testing-mode token expiry, works on a free personal gmail account.

It complements the OAuth-based Google skills already listed (gog, gcal-pro, google-calendar): same APIs, different auth model, with the boundaries documented honestly (can't read unshared private data, can't add attendees — `forbiddenForServiceAccounts`).

Source repo: https://github.com/amiller/awesome-google-service-accounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for Google service accounts integration, describing how to access Google Sheets, Docs, Drive, and Calendar via service-account sharing in the Calendar & Scheduling section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->