### PR TITLE
Add BrowserAct to OpenClaw skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ Or with the ClawHub CLI, for registry-managed skill folders outside a full OpenC
 ```bash
 npx clawhub install <skill-slug>
 ```
+#### BrowserAct CLI
+- [BrowserAct](https://github.com/browser-act/skills): Browser automation CLI built for AI agents. Break through anti-bot wall.
+
 
 #### Manual Installation
 


### PR DESCRIPTION
This PR adds BrowserAct, a browser automation CLI for AI agents, to the OpenClaw skills list.

BrowserAct: https://www.browseract.com/
GitHub: https://github.com/browser-act/skills

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new BrowserAct CLI section to the setup and command-line instructions.
  * Included a short description positioning BrowserAct as a browser automation CLI for AI agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->