### PR TITLE
Add tongtu-china-travel skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 | [Image & Video Generation](#image--video-generation) (170) | [Media & Streaming](#media--streaming) (86) | [PDF & Documents](#pdf--documents) (105) |
 | [Apple Apps & Services](#apple-apps--services) (44) | [Notes & PKM](#notes--pkm) (69) | [Self-Hosted & Automation](#self-hosted--automation) (33) |
 | [Search & Research](#search--research) (345) | [iOS & macOS Development](#ios--macos-development) (29) | [Security & Passwords](#security--passwords) (54) |
-| [Clawdbot Tools](#clawdbot-tools) (37) | [Transportation](#transportation) (110) | [Moltbook](#moltbook) (29) |
+| [Clawdbot Tools](#clawdbot-tools) (37) | [Transportation](#transportation) (111) | [Moltbook](#moltbook) (29) |
 | [CLI Utilities](#cli-utilities) (180) | [Personal Development](#personal-development) (52) | [Gaming](#gaming) (35) |
 | [Health & Fitness](#health--fitness) (87) | | |
 
@@ -829,9 +829,10 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [camino-journey](https://clawskills.sh/skills/james-southendsolutions-camino-journey) - Plan multi-waypoint journeys with route optimization, feasibility analysis, and time budget constraints.
 - [camino-real-estate](https://clawskills.sh/skills/james-southendsolutions-camino-real-estate) - Evaluate any address for home buyers and renters.
 - [camino-route](https://clawskills.sh/skills/james-southendsolutions-camino-route) - Get detailed routing between two points with distance, duration, and optional turn-by-turn directions.
+- [tongtu-china-travel](https://clawhub.ai/jesse-tzx/skills/tongtu-china-travel) - Multilingual travel guide for foreign tourists visiting China — flights, hotels, trains, attractions, visa, payment, and transport via FlyAI.
 - [traffic-standards-kb](https://clawhub.ai/solvex-top/traffic-standards-kb) - Chinese smart transportation standards knowledge base (GB/JT/GA) for writing solutions with industry standard citations.
 
-> **[View all 110 skills in Transportation →](categories/transportation.md)**
+> **[View all 111 skills in Transportation →](categories/transportation.md)**
 </details>
 
 <details>

--- a/categories/transportation.md
+++ b/categories/transportation.md
@@ -2,7 +2,7 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**110 skills**
+**111 skills**
 
 - [accountsos](https://clawskills.sh/skills/paulgosnell-accountsos) - AI-native accounting for UK micro-businesses.
 - [aetherlang-strategy](https://clawskills.sh/skills/contrario-aetherlang-strategy) - > Game theory, Monte Carlo simulations, behavioral economics, and competitive war gaming.
@@ -102,6 +102,7 @@
 - [tfl](https://clawskills.sh/skills/brianleach-tfl) - London TfL transit — real-time Tube arrivals, bus predictions, line status, service disruptions, journey planning.
 - [tixflow](https://clawskills.sh/skills/seenfinity-tixflow) - AI-powered event assistant for discovering, booking, and coordinating event tickets.
 - [tixflow-v2](https://clawskills.sh/skills/seenfinity-tixflow-v2) - AI-powered event assistant for discovering, booking, and coordinating event tickets.
+- [tongtu-china-travel](https://clawhub.ai/jesse-tzx/skills/tongtu-china-travel) - Multilingual travel guide for foreign tourists visiting China — flights, hotels, trains, attractions, visa, payment, and transport via FlyAI.
 - [track-flight](https://clawskills.sh/skills/rafaforesightai-track-flight) - Track flights in real-time with detailed status, gate info, delays, and live position.
 - [translink-cli](https://clawskills.sh/skills/alanburchill-translink-cli) - Query, troubleshoot, and explain Translink SEQ GTFS static + realtime data using local translink_* commands.
 - [travel-agent](https://clawskills.sh/skills/aszelem-travel-agent) - Find, book, and change flights for your human via email.


### PR DESCRIPTION
## Summary

Add **tongtu-china-travel** skill to the Transportation category.

**ClawHub:** https://clawhub.ai/jesse-tzx/skills/tongtu-china-travel  
**GitHub:** https://github.com/jesse-tzx/tongtu-china-travel

### What it does
TongTu is a multilingual travel guide for foreign tourists visiting China. It provides:
- Flight, hotel, train, and attraction search via FlyAI CLI
- Visa guidance (144-hour transit, visa-free countries)
- Payment setup (Alipay, WeChat Pay for foreigners)
- Transport guide (metro, taxi/Didi, intercity, airport transfers)
- Communications (eSIM, local SIM)
- City guides for 10+ major cities

Supports English, Korean, Japanese, and more — all output is in the user's language.

### Checklist
- [x] Skill published on ClawHub (v0.3.1, security scan: Clean)
- [x] Added to `categories/transportation.md`
- [x] Added to `README.md` Transportation section
- [x] Updated skill count (110 → 111)
- [x] Alphabetical order maintained

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Transportation skill entry for travel guidance in China, including help with flights, hotels, trains, attractions, visas, payments, and local transport.
  * Updated the Transportation section count to reflect 111 available skills.
* **Documentation**
  * Refreshed the README Transportation listing and its “View all skills” count to match the updated category content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->