### PR TITLE
docs: add Skill Hub to related resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1245,6 +1245,11 @@ We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed gu
 [![Say hi on X](https://img.shields.io/badge/Say%20Hi!%20👋-%23000000.svg?logo=X&logoColor=white)](https://x.com/nozmen)
 </div>
 
+
+## 🔗 Related
+
+- [ClawHub](https://clawhub.ai) - Official [OpenClaw](https://github.com/VoltAgent/OpenClaw) Skills Registry - browse, search, and publish skills directly
+
 ## License
 
 MIT License - see [LICENSE](LICENSE)


### PR DESCRIPTION
Adds a "Related" section linking to ClawHub and OpenClaw for easier discovery.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new “Related” section to the README with a link to the official skills registry and a short description of how to browse, search, and publish skills.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->