### PR TITLE
Add Atlas Cloud Media API provider resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ openclaw onboard --auth-choice openai-codex
 ```
 </details>
 
+- [Atlas Cloud Media API](https://www.atlascloud.ai/models) provides OpenAI-compatible LLM endpoints and async image/video generation APIs that OpenClaw workflows can call from custom skills or provider integrations.
+
 
 <div align="center">
 


### PR DESCRIPTION
## Summary
- Add Atlas Cloud Media API to the OpenClaw model provider resources
- Keep the change scoped to the existing Model Providers section

## Validation
- README-only change
- Self-reviewed the diff to confirm no sponsor block, logo wall, or promotional placement was added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new example entry for Atlas Cloud Media API under model providers.
  * Clarified that it supports OpenAI-compatible LLM endpoints plus asynchronous image and video generation for workflow use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->