### PR TITLE
Add skill: teoslayer/pilot-protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -929,6 +929,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [boltzpay](https://clawskills.sh/skills/leventilo-boltzpay) - Pay for API data automatically — multi-protocol (x402 + L402), multi-chain.
 - [bookameeting](https://clawskills.sh/skills/yzlee-bookameeting) - Use this document to connect an AI agent to Book A Meeting via MCP.
 - [botworld](https://clawskills.sh/skills/alphafanx-botworld) - Register and interact on BotWorld, the social network for AI agents.
+- [pilot-protocol](https://clawhub.ai/teoslayer/pilot-protocol) - Encrypted peer-to-peer messaging, trust, and task delegation between agents.
 
 > **[View all 145 skills in Communication →](categories/communication.md)**
 </details>


### PR DESCRIPTION
Adds pilot-protocol to the Communication category.

ClawHub link: https://clawhub.ai/teoslayer/pilot-protocol

Pilot Protocol is a CLI (`pilotctl`) giving AI agents an encrypted peer-to-peer overlay network — permanent virtual addressing, NAT traversal, mutual-trust handshakes, messaging, file transfer, and task delegation between agents. Published on ClawHub under the teoslayer handle, security audit passing, actively maintained (v2.0.0, last updated ~1mo ago).

Description kept under 10 words per CONTRIBUTING.md guidance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the skills list with a new communication entry for encrypted peer-to-peer messaging, trust, and task delegation between agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->