### PR TITLE
Add skill: mailnike/erpclaw

### DIFF
--- a/README.md
+++ b/README.md
@@ -1135,6 +1135,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [pinme](https://clawskills.sh/skills/ntlx-pinme) - Deploy static websites to IPFS with a single command using PinMe CLI.
 - [sonarqube-analyzer](https://clawskills.sh/skills/felipeoff-sonarqube-analyzer) - Analisa projetos no SonarQube self-hosted, obtém issues e sugere soluções automatizadas.
 - [system-integrity-and-backup](https://clawskills.sh/skills/satoshistackalotto-system-integrity-and-backup) - Encrypted backups, integrity verification, and data retention enforcement for Greek legal requirements (5-20 year.
+- [erpclaw](https://clawhub.ai/mailnike/erpclaw) - Self-hosted AI-native ERP for running business operations in plain English.
 
 > **[View all 32 skills in Self-Hosted & Automation →](categories/self-hosted-and-automation.md)**
 </details>


### PR DESCRIPTION
Adds [erpclaw](https://clawhub.ai/mailnike/erpclaw) to the Self-Hosted & Automation section.

ClawHub listing: https://clawhub.ai/mailnike/erpclaw (Latest 4.12.1, security status clean)

erpclaw is a self-hosted, open-source ERP skill for running day-to-day business operations in plain English: sales orders, inventory, purchasing, payroll, and multi-company records, with Stripe and Shopify accounting sync as one of its capabilities. SQLite by default, PostgreSQL supported. Built by AvanSaber, GPL v3, actively maintained.

Entry placed at the end of the Self-Hosted & Automation section per CONTRIBUTING, description kept to 10 words.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new entry to the self-hosted automation skills list for an AI-native ERP option, with a link to its ClawHub page and a short description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->