### PR TITLE
Add skill: teoslayer/pilot-protocol

### DIFF
--- a/categories/communication.md
+++ b/categories/communication.md
@@ -110,6 +110,7 @@
 - [personal-friends](https://clawskills.sh/skills/gekacross-personal-friends) - Acts as the user's social life assistant in the Friends topic.
 - [personaldatahub](https://clawskills.sh/skills/haojian-personaldatahub) - Pull personal data (emails, issues) and propose outbound actions (drafts, replies) through the PersonalDataHub.
 - [pidgesms](https://clawskills.sh/skills/typhonius-pidgesms) - Send and read SMS text messages via an Android phone using pidge.
+- [pilot-protocol](https://clawhub.ai/teoslayer/pilot-protocol) - Encrypted P2P messaging and trust handshakes between AI agents over Pilot Protocol's overlay network.
 - [portfolio-watcher](https://clawskills.sh/skills/jhillin8-portfolio-watcher) - Monitor stock/crypto holdings, get price alerts, track portfolio performance.
 - [postwall](https://clawskills.sh/skills/casperaiassist-postwall) - Secure email gateway for AI agents - human-in-the-loop approval for reading and sending emails.
 - [price-monitor-fr](https://clawskills.sh/skills/hugosbl-price-monitor-fr) - Surveille les prix de produits sur des sites e-commerce et alerte quand ils baissent.


### PR DESCRIPTION
Adds pilot-protocol to the Communication category.

ClawHub link: https://clawhub.ai/teoslayer/pilot-protocol

Gives OpenClaw agents an encrypted peer-to-peer messaging layer with explicit per-peer trust handshakes (mutual approve) plus permanent addressing and NAT traversal — lets agents talk to other agents directly rather than through a shared platform. Similar niche to agentmesh already listed in this category, but focused on general-purpose agent-to-agent networking/trust rather than a single messaging protocol.