### PR TITLE
Add feishu-agent-communication to communication category

### DIFF
--- a/categories/communication.md
+++ b/categories/communication.md
@@ -146,3 +146,5 @@
 - [youam](https://clawskills.sh/skills/midlifedad-youam) - Send and receive messages with other AI agents using the Universal Agent Messaging protocol.
 - [zepto](https://clawskills.sh/skills/bewithgaurav-zepto) - Order groceries from Zepto in seconds.
 - [lobstermail-agent-email](https://clawskills.sh/skills/samuelchenardlovesboards-lobstermail-agent-email) - Email for AI agents. No API keys, no signup.
+
+- [feishu-agent-communication](https://github.com/zhouxin121/feishu-agent-communication) - 飞书多Agent群聊通信：Bot间互@通信方案。框架无关，扫码直连，text格式+open_id隔离+LLM防呆。13版迭代实测验证。


### PR DESCRIPTION
飞书多Agent群聊通信 Skill — 框架无关的 Bot 间互@方案，13版迭代实测验证。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added the `feishu-agent-communication` skill to the communication skills listing.
  - Included its repository link and a description of Feishu multi-agent group chat messaging capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->