### PR TITLE
Add skill: ohad6k/ditto-profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [skywork-ppt](https://clawskills.sh/skills/gxcun17-skywork-ppt) - Generate, imitate, and edit PowerPoint presentations with skywork.
 - [skywork-music-maker](https://clawskills.sh/skills/gxcun17-skywork-music-maker) - Create professional music with Mureka AI.
 - [before-you-build](https://clawhub.ai/bin1874/before-you-build) - Review product risk before building.
+- [ditto-profile](https://clawhub.ai/ohad6k/ditto-profile) - Load your mined personal profile so agents work like you.
 
 > **[View all 1200 skills in Coding Agents & IDEs →](categories/coding-agents-and-ides.md)**
 </details>


### PR DESCRIPTION
Adds Ditto to the Coding Agents & IDEs section. It is a ClawHub-published skill at https://clawhub.ai/ohad6k/ditto-profile that loads a user's personal profile, mined from their local Claude Code, Codex, and OpenCode session logs, so the agent works like them instead of a cold start. The skill runs the ditto CLI via uvx to load the profile; nothing is bundled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the “ditto-profile” skill to the Coding Agents & IDEs section of the README, including a link and brief description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->