### PR TITLE
Add skill: sergebulaev/linkedin-post-writer

### DIFF
--- a/categories/marketing-and-sales.md
+++ b/categories/marketing-and-sales.md
@@ -2,7 +2,7 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**106 skills**
+**107 skills**
 
 - [4chan-reader](https://clawskills.sh/skills/aiasisbot61-4chan-reader) - Browse 4chan boards and extract thread discussions.
 - [ad-ready](https://clawskills.sh/skills/pauldelavallaz-ad-ready) - Generate professional advertising images from product URLs.
@@ -106,3 +106,4 @@
 - [ldm-openclaw-skill](https://clawhub.ai/live-direct-marketing/ldm-openclaw-skill) - Pre-send deliverability checks for outbound agents.
 - [ldm-openclaw-inbox-mcp-skill](https://clawhub.ai/live-direct-marketing/ldm-openclaw-inbox-mcp-skill) - Paid MCP inbox-placement checks for outbound agents.
 - [tempguru-event-staffing-ordering](https://clawhub.ai/kissmyabs32/tempguru-event-staffing-ordering) - Order W-2 temporary event staff across 345 US/Canada markets.
+- [linkedin-post-writer](https://clawhub.ai/sergebulaev/linkedin-post-writer) - LinkedIn marketing skills: viral hooks, comments, algorithm audit, humanizer.


### PR DESCRIPTION
Resubmitting per the CONTRIBUTING guide (the earlier #420 predated it and linked the old clawskills.sh domain).

- **Published on ClawHub:** https://clawhub.ai/sergebulaev/linkedin-post-writer (author page: https://clawhub.ai/sergebulaev)
- **One representative link, not one-per-skill**, as the guide asks. linkedin-post-writer is the flagship of an 11-skill LinkedIn marketing bundle (viral hook formulas, comment drafting, a 20-point algorithm audit, an AI-tell humanizer, hook extractor, content planner, profile optimizer).
- **Matured:** 378 stars, 55 forks, months in production, MIT.
- Added one entry to the end of **Marketing & Sales** and bumped the count 106 to 107. Description is under 10 words. Not crypto/finance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the LinkedIn Post Writer skill, including support for viral hooks, comment generation, algorithm audits, and humanized content.

* **Documentation**
  * Updated the Marketing & Sales catalog to reflect the addition, increasing the total to 107 skills.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->