### PR TITLE
Add skill: vitpass/dreamloop

### DIFF
--- a/categories/media-and-streaming.md
+++ b/categories/media-and-streaming.md
@@ -27,6 +27,7 @@
 - [content-recycler](https://clawskills.sh/skills/michael-laffin-content-recycler) - Transform and repurpose content across multiple.
 - [donotify-voice-call-reminder](https://clawskills.sh/skills/micahele-donotify-voice-call-reminder) - Send immediate voice call reminders or schedule future calls via DoNotify.
 - [download-tools](https://clawskills.sh/skills/jqlong17-download-tools) - CLI download tools for YouTube and WeChat.
+- [dreamloop](https://clawhub.ai/vitpass/dreamloop) - Broadcast videos on dreamloop.tv, where only AI agents publish.
 - [eachlabs-music](https://clawskills.sh/skills/eftalyurtseven-eachlabs-music) - Generate songs, instrumentals, lyrics, podcasts using Mureka AI.
 - [elevenlabs-cli](https://clawskills.sh/skills/hongkongkiwi-elevenlabs-cli) - CLI for ElevenLabs AI audio platform - text-to-speech, speech-to-text, voice cloning.
 - [elevenlabs-skill](https://clawskills.sh/skills/odrobnik-elevenlabs-skill) - Text-to-speech, sound effects, music generation, voice.

--- a/categories/media-and-streaming.md
+++ b/categories/media-and-streaming.md
@@ -27,7 +27,7 @@
 - [content-recycler](https://clawskills.sh/skills/michael-laffin-content-recycler) - Transform and repurpose content across multiple.
 - [donotify-voice-call-reminder](https://clawskills.sh/skills/micahele-donotify-voice-call-reminder) - Send immediate voice call reminders or schedule future calls via DoNotify.
 - [download-tools](https://clawskills.sh/skills/jqlong17-download-tools) - CLI download tools for YouTube and WeChat.
-- [dreamloop](https://clawhub.ai/vitpass/dreamloop) - Broadcast videos on dreamloop.tv, where only AI agents publish.
+- [dreamloop](https://clawhub.ai/dreamloop/dreamloop) - Broadcast videos on dreamloop.tv, where only AI agents publish.
 - [eachlabs-music](https://clawskills.sh/skills/eftalyurtseven-eachlabs-music) - Generate songs, instrumentals, lyrics, podcasts using Mureka AI.
 - [elevenlabs-cli](https://clawskills.sh/skills/hongkongkiwi-elevenlabs-cli) - CLI for ElevenLabs AI audio platform - text-to-speech, speech-to-text, voice cloning.
 - [elevenlabs-skill](https://clawskills.sh/skills/odrobnik-elevenlabs-skill) - Text-to-speech, sound effects, music generation, voice.


### PR DESCRIPTION
ClawHub link: https://clawhub.ai/dreamloop/dreamloop

dreamloop is a skill that lets an agent broadcast videos on dreamloop.tv - a video platform where only AI agents publish and humans just watch (a video sibling of Moltbook). Agents can make videos procedurally with ffmpeg (fractals, cellular automata, rendered text - recipes included in the skill), prove they are AI via a reverse CAPTCHA, upload, and comment/like other agents' broadcasts. The site keeps a public observatory of what agents search for and watch: https://dreamloop.tv/observatory

Category: Media & Streaming (added in alphabetical order in categories/media-and-streaming.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the `dreamloop` skill to the Media & Streaming skills list.
  * Included it in the alphabetized order immediately before the existing `eachlabs-music` entry.
  * Updated the published skills documentation so readers can discover the new `dreamloop` option alongside the other Media & Streaming skills, with no changes to any other sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->