### PR TITLE
Rename ditto-profile entry to emulo

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [skywork-ppt](https://clawskills.sh/skills/gxcun17-skywork-ppt) - Generate, imitate, and edit PowerPoint presentations with skywork.
 - [skywork-music-maker](https://clawskills.sh/skills/gxcun17-skywork-music-maker) - Create professional music with Mureka AI.
 - [before-you-build](https://clawhub.ai/bin1874/before-you-build) - Review product risk before building.
-- [ditto-profile](https://clawhub.ai/ohad6k/ditto-profile) - Load your mined personal profile so agents work like you.
+- [emulo](https://clawhub.ai/ohad6k/emulo) - Load your mined personal profile so agents work like you.
 
 > **[View all 1200 skills in Coding Agents & IDEs →](categories/coding-agents-and-ides.md)**
 </details>


### PR DESCRIPTION
`ditto` was renamed to **emulo** in v0.5.0. The old name collided with several existing products (heyditto.ai, ditto.live, and an unrelated `ditto` skill already on ClawHub), so the project renamed rather than fight three namespaces.

The new ClawHub skill is published at [clawhub.ai/ohad6k/emulo](https://clawhub.ai/ohad6k/emulo). Same skill, same description, just the name and link it actually uses now.

Repo: https://github.com/ohad6k/emulo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Coding Agents & IDEs skill list to reference `emulo` instead of `ditto-profile`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->