### PR TITLE
Add skill: iammuneeb/postnitro

### DIFF
--- a/categories/marketing-and-sales.md
+++ b/categories/marketing-and-sales.md
@@ -2,7 +2,7 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**106 skills**
+**107 skills**
 
 - [4chan-reader](https://clawskills.sh/skills/aiasisbot61-4chan-reader) - Browse 4chan boards and extract thread discussions.
 - [ad-ready](https://clawskills.sh/skills/pauldelavallaz-ad-ready) - Generate professional advertising images from product URLs.

--- a/categories/marketing-and-sales.md
+++ b/categories/marketing-and-sales.md
@@ -106,3 +106,4 @@
 - [ldm-openclaw-skill](https://clawhub.ai/live-direct-marketing/ldm-openclaw-skill) - Pre-send deliverability checks for outbound agents.
 - [ldm-openclaw-inbox-mcp-skill](https://clawhub.ai/live-direct-marketing/ldm-openclaw-inbox-mcp-skill) - Paid MCP inbox-placement checks for outbound agents.
 - [tempguru-event-staffing-ordering](https://clawhub.ai/kissmyabs32/tempguru-event-staffing-ordering) - Order W-2 temporary event staff across 345 US/Canada markets.
+- [postnitro](https://clawhub.ai/iammuneeb/skills/postnitro) - Create on-brand social media carousels and single-image posts and schedule them to LinkedIn, Instagram, TikTok, and Threads.


### PR DESCRIPTION
Published on Clawhub: https://clawhub.ai/iammuneeb/skills/postnitro

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PostNitro to the Marketing & Sales skills list.
  * Create on-brand social media carousels and single-image posts.
  * Schedule content across LinkedIn, Instagram, TikTok, and Threads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->