### PR TITLE
Add skill: modellix/modellix

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [skywork-design](https://clawskills.sh/skills/gxcun17-skywork-design) - Generate and edit images via Skywork Image for posters, logos and more.
 
 - [ai-video-remix](https://clawskills.sh/skills/abu-shotai-ai-video-remix) - AI-driven video remix from local library using ShotAI.
+- [modellix](https://clawhub.ai/modellix/modellix) - Unified API for AI image and video generation.
 > **[View all 170 skills in Image & Video Generation →](categories/image-and-video-generation.md)**
 </details>
 

--- a/categories/image-and-video-generation.md
+++ b/categories/image-and-video-generation.md
@@ -110,6 +110,7 @@
 - [mindmap-generator](https://clawskills.sh/skills/parasharnagle-mindmap-generator) - Generates visual mindmap images from conversations, goals, decisions, and daily priorities — delivered as PNG.
 - [mixtiles-it](https://clawskills.sh/skills/saharcarmel-mixtiles-it) - Send a photo to Mixtiles for ordering wall tiles.
 - [moonfunsdk](https://clawskills.sh/skills/moonnfunofficial-moonfunsdk) - Professional Python SDK for creating and trading Meme tokens on Binance Smart Chain with AI-powered image generation.
+- [modellix](https://clawhub.ai/modellix/modellix) - Unified API for AI image and video generation.
 - [nanobanana-pro-fallback](https://clawskills.sh/skills/yazelin-nanobanana-pro-fallback) - Nano Banana Pro with auto model fallback — generate/edit images via Gemini Image API.
 - [nk-images-search](https://clawskills.sh/skills/tompltw-nk-images-search) - Search 1+ million free high-quality AI stock photos.
 - [nyne-deep-research](https://clawskills.sh/skills/michaelfanous2-nyne-deep-research) - Research any person using the Nyne Deep Research API.


### PR DESCRIPTION
## Summary
Add Modellix to Image & Video Generation.

ClawHub: https://clawhub.ai/modellix/modellix

Official skill for unified AI image/video generation via Modellix CLI/API.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the `modellix` skill to the Image & Video Generation catalog.
  * Included its ClawHub link and description as a unified API for AI image and video generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->