### PR TITLE
Add skill: atomicmail/atomicmail

### DIFF
--- a/categories/communication.md
+++ b/categories/communication.md
@@ -147,3 +147,4 @@
 - [zepto](https://clawskills.sh/skills/bewithgaurav-zepto) - Order groceries from Zepto in seconds.
 - [lobstermail-agent-email](https://clawskills.sh/skills/samuelchenardlovesboards-lobstermail-agent-email) - Email for AI agents. No API keys, no signup.
 - [sol-email](https://clawhub.ai/amrree/sol-email) - Read and send emails via himalaya (Maildir) and SMTP. Real inbox, real replies.
+- [atomicmail](https://clawhub.ai/atomicmail/atomicmail) - Agent-owned @atomicmail.ai inbox over JMAP. PoW signup, no API keys.


### PR DESCRIPTION
Adds `atomicmail` to the Communication category.

ClawHub page (for verification): https://clawhub.ai/atomicmail/atomicmail

- **Published on ClawHub:** yes, `@atomicmail/atomicmail`, current version v0.3.24
- **Usage:** 575 downloads all-time on ClawHub, 306 in the last 30 days
- **Security:** ClawHub security audit status **Pass**; VirusTotal 63/63 vendors clean
- **Docs:** SKILL.md included

A programmable `@atomicmail.ai` inbox for agents over JMAP — proof-of-work signup, so no API keys and no human verification step.

One entry, appended to the end of the category, per CONTRIBUTING.

Note on placement: CONTRIBUTING says to add the entry to `README.md`, but the Communication section there is a truncated 25-item excerpt that links out to `categories/communication.md` for the full list. I followed the pattern of the most recent entries and appended to the category file — happy to move it to `README.md` instead if that's what you'd prefer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AtomicMail to the Communication skills list, highlighting agent-owned inboxes, JMAP support, proof-of-work signup, and API-key-free access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->