### PR TITLE
Add ForeverBetter healthspan skills 🦞

### DIFF
--- a/README.md
+++ b/README.md
@@ -879,7 +879,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 <summary><h3 style="display:inline">Health & Fitness</h3></summary>
 
 - [31third-safe-rebalancer-simple](https://clawskills.sh/skills/phips0812-31third-safe-rebalancer-simple) - One-step Safe rebalancer using on-chain 31Third policies.
-- [analyze-longevity](https://clawskills.sh/skills/liveforeverbetter-analyze-longevity) - Comprehensive healthspan analysis interpreting Whole Genome Sequencing (WGS VCF with ClinVar, CPIC pharmacogenomics, PRS), 168+ biomarkers across 6 panels, and wearable data. MIT licensed.
+- [analyze-longevity](https://clawskills.sh/skills/liveforeverbetter-analyze-longevity) - Agent-native healthspan analysis interpreting Whole Genome Sequencing (WGS VCF with ClinVar, CPIC pharmacogenomics, PRS), 168+ biomarkers across 6 panels, and wearable data. MIT licensed.
 - [anthrovision-telegram-body-scan](https://clawskills.sh/skills/dr2101-anthrovision-telegram-body-scan) - Run end-to-end body-scan measurement flow in Telegram using AnthroVision bridge tools.
 - [aperture](https://clawskills.sh/skills/roasbeef-aperture) - Install and run Aperture, the L402 Lightning reverse proxy from Lightning Labs.
 - [arc-skill-sandbox](https://clawskills.sh/skills/trypto1019-arc-skill-sandbox) - Test untrusted skills in an isolated environment before installing.
@@ -905,7 +905,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [eth24](https://clawskills.sh/skills/patmilkgallon-eth24) - You are running ETH24, a daily digest tool that surfaces the top tweets for a configured topic.
 - [fasting-tracker](https://clawskills.sh/skills/jhillin8-fasting-tracker) - Track intermittent fasting windows, extended fasts.
 
-- [wellnizz](https://clawskills.sh/skills/liveforeverbetter-wellnizz) - Connects agents to ForeverBetter hosted health API. 21 MCP tools for querying biomarkers, wearable data from WHOOP/Oura/Garmin, and genomic analysis. Self-hostable (Docker).
+- [wellnizz](https://clawskills.sh/skills/liveforeverbetter-wellnizz) - Agent-native health API connector with 21 MCP tools for querying biomarkers, wearable data from WHOOP/Oura/Garmin, and genomic analysis. Self-hostable (Docker).
 
 > **[View all 86 skills in Health & Fitness →](categories/health-and-fitness.md)**
 </details>

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 | [Search & Research](#search--research) (345) | [iOS & macOS Development](#ios--macos-development) (29) | [Security & Passwords](#security--passwords) (54) |
 | [Clawdbot Tools](#clawdbot-tools) (37) | [Transportation](#transportation) (111) | [Moltbook](#moltbook) (29) |
 | [CLI Utilities](#cli-utilities) (180) | [Personal Development](#personal-development) (52) | [Gaming](#gaming) (35) |
-| [Health & Fitness](#health--fitness) (87) | | |
+| [Health & Fitness](#health--fitness) (89) | | |
 
 
 
@@ -879,6 +879,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 <summary><h3 style="display:inline">Health & Fitness</h3></summary>
 
 - [31third-safe-rebalancer-simple](https://clawskills.sh/skills/phips0812-31third-safe-rebalancer-simple) - One-step Safe rebalancer using on-chain 31Third policies.
+- [analyze-longevity](https://clawskills.sh/skills/liveforeverbetter-analyze-longevity) - Comprehensive healthspan analysis interpreting Whole Genome Sequencing (WGS VCF with ClinVar, CPIC pharmacogenomics, PRS), 168+ biomarkers across 6 panels, and wearable data. MIT licensed.
 - [anthrovision-telegram-body-scan](https://clawskills.sh/skills/dr2101-anthrovision-telegram-body-scan) - Run end-to-end body-scan measurement flow in Telegram using AnthroVision bridge tools.
 - [aperture](https://clawskills.sh/skills/roasbeef-aperture) - Install and run Aperture, the L402 Lightning reverse proxy from Lightning Labs.
 - [arc-skill-sandbox](https://clawskills.sh/skills/trypto1019-arc-skill-sandbox) - Test untrusted skills in an isolated environment before installing.
@@ -904,7 +905,9 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [eth24](https://clawskills.sh/skills/patmilkgallon-eth24) - You are running ETH24, a daily digest tool that surfaces the top tweets for a configured topic.
 - [fasting-tracker](https://clawskills.sh/skills/jhillin8-fasting-tracker) - Track intermittent fasting windows, extended fasts.
 
-> **[View all 84 skills in Health & Fitness →](categories/health-and-fitness.md)**
+- [wellnizz](https://clawskills.sh/skills/liveforeverbetter-wellnizz) - Connects agents to ForeverBetter hosted health API. 21 MCP tools for querying biomarkers, wearable data from WHOOP/Oura/Garmin, and genomic analysis. Self-hostable (Docker).
+
+> **[View all 86 skills in Health & Fitness →](categories/health-and-fitness.md)**
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -879,7 +879,6 @@ If you believe a skill in this list should be flagged or has a security concern,
 <summary><h3 style="display:inline">Health & Fitness</h3></summary>
 
 - [31third-safe-rebalancer-simple](https://clawskills.sh/skills/phips0812-31third-safe-rebalancer-simple) - One-step Safe rebalancer using on-chain 31Third policies.
-- [analyze-longevity](https://clawskills.sh/skills/liveforeverbetter-analyze-longevity) - Agent-first healthspan analysis: Whole Genome Sequencing (WGS VCF with ClinVar, CPIC pharmacogenomics, PRS), 168+ biomarkers, and wearable data. MIT licensed.
 - [anthrovision-telegram-body-scan](https://clawskills.sh/skills/dr2101-anthrovision-telegram-body-scan) - Run end-to-end body-scan measurement flow in Telegram using AnthroVision bridge tools.
 - [aperture](https://clawskills.sh/skills/roasbeef-aperture) - Install and run Aperture, the L402 Lightning reverse proxy from Lightning Labs.
 - [arc-skill-sandbox](https://clawskills.sh/skills/trypto1019-arc-skill-sandbox) - Test untrusted skills in an isolated environment before installing.
@@ -907,7 +906,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 
 - [wellnizz](https://clawskills.sh/skills/liveforeverbetter-wellnizz) - Agent-first API for genetics, biomarkers, and wearables. 21 MCP tools for querying biomarkers, wearable data from WHOOP/Oura/Garmin, and genomic analysis.
 
-> **[View all 86 skills in Health & Fitness →](categories/health-and-fitness.md)**
+> **[View all 85 skills in Health & Fitness →](categories/health-and-fitness.md)**
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -879,7 +879,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 <summary><h3 style="display:inline">Health & Fitness</h3></summary>
 
 - [31third-safe-rebalancer-simple](https://clawskills.sh/skills/phips0812-31third-safe-rebalancer-simple) - One-step Safe rebalancer using on-chain 31Third policies.
-- [analyze-longevity](https://clawskills.sh/skills/liveforeverbetter-analyze-longevity) - Agent-native healthspan analysis interpreting Whole Genome Sequencing (WGS VCF with ClinVar, CPIC pharmacogenomics, PRS), 168+ biomarkers across 6 panels, and wearable data. MIT licensed.
+- [analyze-longevity](https://clawskills.sh/skills/liveforeverbetter-analyze-longevity) - Agent-first healthspan analysis: Whole Genome Sequencing (WGS VCF with ClinVar, CPIC pharmacogenomics, PRS), 168+ biomarkers, and wearable data. MIT licensed.
 - [anthrovision-telegram-body-scan](https://clawskills.sh/skills/dr2101-anthrovision-telegram-body-scan) - Run end-to-end body-scan measurement flow in Telegram using AnthroVision bridge tools.
 - [aperture](https://clawskills.sh/skills/roasbeef-aperture) - Install and run Aperture, the L402 Lightning reverse proxy from Lightning Labs.
 - [arc-skill-sandbox](https://clawskills.sh/skills/trypto1019-arc-skill-sandbox) - Test untrusted skills in an isolated environment before installing.
@@ -905,7 +905,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [eth24](https://clawskills.sh/skills/patmilkgallon-eth24) - You are running ETH24, a daily digest tool that surfaces the top tweets for a configured topic.
 - [fasting-tracker](https://clawskills.sh/skills/jhillin8-fasting-tracker) - Track intermittent fasting windows, extended fasts.
 
-- [wellnizz](https://clawskills.sh/skills/liveforeverbetter-wellnizz) - Agent-native health API connector with 21 MCP tools for querying biomarkers, wearable data from WHOOP/Oura/Garmin, and genomic analysis. Self-hostable (Docker).
+- [wellnizz](https://clawskills.sh/skills/liveforeverbetter-wellnizz) - Agent-first API for genetics, biomarkers, and wearables. 21 MCP tools for querying biomarkers, wearable data from WHOOP/Oura/Garmin, and genomic analysis.
 
 > **[View all 86 skills in Health & Fitness →](categories/health-and-fitness.md)**
 </details>

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 | [Search & Research](#search--research) (345) | [iOS & macOS Development](#ios--macos-development) (29) | [Security & Passwords](#security--passwords) (54) |
 | [Clawdbot Tools](#clawdbot-tools) (37) | [Transportation](#transportation) (111) | [Moltbook](#moltbook) (29) |
 | [CLI Utilities](#cli-utilities) (180) | [Personal Development](#personal-development) (52) | [Gaming](#gaming) (35) |
-| [Health & Fitness](#health--fitness) (89) | | |
+| [Health & Fitness](#health--fitness) (85) | | |
 
 
 

--- a/categories/health-and-fitness.md
+++ b/categories/health-and-fitness.md
@@ -5,7 +5,7 @@
 **86 skills**
 
 - [31third-safe-rebalancer-simple](https://clawskills.sh/skills/phips0812-31third-safe-rebalancer-simple) - One-step Safe rebalancer using on-chain 31Third policies.
-- [analyze-longevity](https://clawskills.sh/skills/liveforeverbetter-analyze-longevity) - Comprehensive healthspan analysis interpreting Whole Genome Sequencing (WGS VCF with ClinVar, CPIC pharmacogenomics, PRS), 168+ biomarkers across 6 panels, and wearable data. MIT licensed.
+- [analyze-longevity](https://clawskills.sh/skills/liveforeverbetter-analyze-longevity) - Agent-native healthspan analysis interpreting Whole Genome Sequencing (WGS VCF with ClinVar, CPIC pharmacogenomics, PRS), 168+ biomarkers across 6 panels, and wearable data. MIT licensed.
 - [anthrovision-telegram-body-scan](https://clawskills.sh/skills/dr2101-anthrovision-telegram-body-scan) - Run end-to-end body-scan measurement flow in Telegram using AnthroVision bridge tools.
 - [aperture](https://clawskills.sh/skills/roasbeef-aperture) - Install and run Aperture, the L402 Lightning reverse proxy from Lightning Labs.
 - [arc-skill-sandbox](https://clawskills.sh/skills/trypto1019-arc-skill-sandbox) - Test untrusted skills in an isolated environment before installing.
@@ -85,7 +85,7 @@
 - [usdc-hackathon](https://clawskills.sh/skills/swairshah-usdc-hackathon) - Use when participating in the USDC Hackathon, submitting projects, or voting. 3 tracks: SmartContract, Skill.
 - [uv-priority](https://clawskills.sh/skills/marcoracer-uv-priority) - Prioritize uv over pip for all Python package management and execution.
 - [vynn-backtester](https://clawskills.sh/skills/beee003-vynn-backtester) - Run trading strategy backtests with natural language — powered by Vynn.
-- [wellnizz](https://clawskills.sh/skills/liveforeverbetter-wellnizz) - Connects agents to ForeverBetter hosted health API. 21 MCP tools for querying biomarkers, wearable data from WHOOP/Oura/Garmin, and genomic analysis. Self-hostable (Docker).
+- [wellnizz](https://clawskills.sh/skills/liveforeverbetter-wellnizz) - Agent-native health API connector with 21 MCP tools for querying biomarkers, wearable data from WHOOP/Oura/Garmin, and genomic analysis. Self-hostable (Docker).
 - [xrpl-tx-builder](https://clawskills.sh/skills/harleyscodes-xrpl-tx-builder) - Build and sign XRP Ledger transactions.
 - [yumstock](https://clawskills.sh/skills/yumyumtum-yumstock) - Macro-gated US stock analysis combining technical indicators, fundamentals, and macro environment with weighted.
 - [signet-guide](https://clawhub.ai/amrree/signet-guide) - Getting started with Signet Mind — local mental health companion with grounding exercises and mood tracking.

--- a/categories/health-and-fitness.md
+++ b/categories/health-and-fitness.md
@@ -2,10 +2,9 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**86 skills**
+**85 skills**
 
 - [31third-safe-rebalancer-simple](https://clawskills.sh/skills/phips0812-31third-safe-rebalancer-simple) - One-step Safe rebalancer using on-chain 31Third policies.
-- [analyze-longevity](https://clawskills.sh/skills/liveforeverbetter-analyze-longevity) - Agent-first healthspan analysis: Whole Genome Sequencing (WGS VCF with ClinVar, CPIC pharmacogenomics, PRS), 168+ biomarkers, and wearable data. MIT licensed.
 - [anthrovision-telegram-body-scan](https://clawskills.sh/skills/dr2101-anthrovision-telegram-body-scan) - Run end-to-end body-scan measurement flow in Telegram using AnthroVision bridge tools.
 - [aperture](https://clawskills.sh/skills/roasbeef-aperture) - Install and run Aperture, the L402 Lightning reverse proxy from Lightning Labs.
 - [arc-skill-sandbox](https://clawskills.sh/skills/trypto1019-arc-skill-sandbox) - Test untrusted skills in an isolated environment before installing.

--- a/categories/health-and-fitness.md
+++ b/categories/health-and-fitness.md
@@ -2,9 +2,10 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**84 skills**
+**86 skills**
 
 - [31third-safe-rebalancer-simple](https://clawskills.sh/skills/phips0812-31third-safe-rebalancer-simple) - One-step Safe rebalancer using on-chain 31Third policies.
+- [analyze-longevity](https://clawskills.sh/skills/liveforeverbetter-analyze-longevity) - Comprehensive healthspan analysis interpreting Whole Genome Sequencing (WGS VCF with ClinVar, CPIC pharmacogenomics, PRS), 168+ biomarkers across 6 panels, and wearable data. MIT licensed.
 - [anthrovision-telegram-body-scan](https://clawskills.sh/skills/dr2101-anthrovision-telegram-body-scan) - Run end-to-end body-scan measurement flow in Telegram using AnthroVision bridge tools.
 - [aperture](https://clawskills.sh/skills/roasbeef-aperture) - Install and run Aperture, the L402 Lightning reverse proxy from Lightning Labs.
 - [arc-skill-sandbox](https://clawskills.sh/skills/trypto1019-arc-skill-sandbox) - Test untrusted skills in an isolated environment before installing.
@@ -84,6 +85,7 @@
 - [usdc-hackathon](https://clawskills.sh/skills/swairshah-usdc-hackathon) - Use when participating in the USDC Hackathon, submitting projects, or voting. 3 tracks: SmartContract, Skill.
 - [uv-priority](https://clawskills.sh/skills/marcoracer-uv-priority) - Prioritize uv over pip for all Python package management and execution.
 - [vynn-backtester](https://clawskills.sh/skills/beee003-vynn-backtester) - Run trading strategy backtests with natural language — powered by Vynn.
+- [wellnizz](https://clawskills.sh/skills/liveforeverbetter-wellnizz) - Connects agents to ForeverBetter hosted health API. 21 MCP tools for querying biomarkers, wearable data from WHOOP/Oura/Garmin, and genomic analysis. Self-hostable (Docker).
 - [xrpl-tx-builder](https://clawskills.sh/skills/harleyscodes-xrpl-tx-builder) - Build and sign XRP Ledger transactions.
 - [yumstock](https://clawskills.sh/skills/yumyumtum-yumstock) - Macro-gated US stock analysis combining technical indicators, fundamentals, and macro environment with weighted.
 - [signet-guide](https://clawhub.ai/amrree/signet-guide) - Getting started with Signet Mind — local mental health companion with grounding exercises and mood tracking.

--- a/categories/health-and-fitness.md
+++ b/categories/health-and-fitness.md
@@ -5,7 +5,7 @@
 **86 skills**
 
 - [31third-safe-rebalancer-simple](https://clawskills.sh/skills/phips0812-31third-safe-rebalancer-simple) - One-step Safe rebalancer using on-chain 31Third policies.
-- [analyze-longevity](https://clawskills.sh/skills/liveforeverbetter-analyze-longevity) - Agent-native healthspan analysis interpreting Whole Genome Sequencing (WGS VCF with ClinVar, CPIC pharmacogenomics, PRS), 168+ biomarkers across 6 panels, and wearable data. MIT licensed.
+- [analyze-longevity](https://clawskills.sh/skills/liveforeverbetter-analyze-longevity) - Agent-first healthspan analysis: Whole Genome Sequencing (WGS VCF with ClinVar, CPIC pharmacogenomics, PRS), 168+ biomarkers, and wearable data. MIT licensed.
 - [anthrovision-telegram-body-scan](https://clawskills.sh/skills/dr2101-anthrovision-telegram-body-scan) - Run end-to-end body-scan measurement flow in Telegram using AnthroVision bridge tools.
 - [aperture](https://clawskills.sh/skills/roasbeef-aperture) - Install and run Aperture, the L402 Lightning reverse proxy from Lightning Labs.
 - [arc-skill-sandbox](https://clawskills.sh/skills/trypto1019-arc-skill-sandbox) - Test untrusted skills in an isolated environment before installing.
@@ -85,7 +85,7 @@
 - [usdc-hackathon](https://clawskills.sh/skills/swairshah-usdc-hackathon) - Use when participating in the USDC Hackathon, submitting projects, or voting. 3 tracks: SmartContract, Skill.
 - [uv-priority](https://clawskills.sh/skills/marcoracer-uv-priority) - Prioritize uv over pip for all Python package management and execution.
 - [vynn-backtester](https://clawskills.sh/skills/beee003-vynn-backtester) - Run trading strategy backtests with natural language — powered by Vynn.
-- [wellnizz](https://clawskills.sh/skills/liveforeverbetter-wellnizz) - Agent-native health API connector with 21 MCP tools for querying biomarkers, wearable data from WHOOP/Oura/Garmin, and genomic analysis. Self-hostable (Docker).
+- [wellnizz](https://clawskills.sh/skills/liveforeverbetter-wellnizz) - Agent-first API for genetics, biomarkers, and wearables. 21 MCP tools for querying biomarkers, wearable data from WHOOP/Oura/Garmin, and genomic analysis.
 - [xrpl-tx-builder](https://clawskills.sh/skills/harleyscodes-xrpl-tx-builder) - Build and sign XRP Ledger transactions.
 - [yumstock](https://clawskills.sh/skills/yumyumtum-yumstock) - Macro-gated US stock analysis combining technical indicators, fundamentals, and macro environment with weighted.
 - [signet-guide](https://clawhub.ai/amrree/signet-guide) - Getting started with Signet Mind — local mental health companion with grounding exercises and mood tracking.


### PR DESCRIPTION
Adds two ForeverBetter skills to the Health & Fitness section:

- **analyze-longevity**: Comprehensive healthspan analysis interpreting Whole Genome Sequencing (WGS VCF with ClinVar, CPIC pharmacogenomics, PRS), 168+ biomarkers across 6 panels, and wearable data. MIT licensed. Install: `npx skills add liveforeverbetter/agentic-longevity-analysis`. Supports OpenClaw, Claude Code, Codex, Hermes.

- **wellnizz**: Connects agents to ForeverBetter hosted health API. 21 MCP tools for querying biomarkers, wearable data from WHOOP/Oura/Garmin, and genomic analysis. Self-hostable (Docker). Install: `npx skills add liveforeverbetter/wellnizz --skill wellnizz`. Supports OpenClaw, Claude Code, Codex, Hermes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation / Content Updates**
  * Added a new **Health & Fitness** skill entry: `wellnizz`.
  * Updated the displayed **Health & Fitness** skill totals across the category page and related listings (now **85**), including the table of contents and the “View all” footer count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->