### PR TITLE
Add skill: zatmonkey/newsflash

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [openclaw-free-web-search](https://clawskills.sh/skills/wd041216-bit-openclaw-free-web-search) - Free, private web search for OpenClaw with self-hosted SearXNG + Scrapling anti-bot + multi-source cross-validation. Zero API keys, zero cost. Tells you how much to trust the answer.
 - [xquik-x-twitter-scraper](https://clawskills.sh/skills/kriptoburak-xquik-x-twitter-scraper) - X API scraper with 40+ tools for AI agents.
 - [skywork-search](https://clawskills.sh/skills/gxcun17-skywork-search) - AI-powered web search for real-time information — retrieve up-to-date content.
+- [newsflash](https://clawhub.ai/zatmonkey/newsflash) - Corroborated real-time news briefings and alerts for agents.
 
 > **[View all 352 skills in Search & Research →](categories/search-and-research.md)**
 </details>


### PR DESCRIPTION
Adds [newsflash](https://clawhub.ai/zatmonkey/newsflash) to Search & Research. Disclosure: I built Newsflash. It's a hosted service that crawls 260+ global sources in 21 languages, dedupes them into an event graph with corroboration counts and confidence scores, and the skill turns that into a personalized daily briefing plus real-time breaking-news alerts from its SSE stream. It works keyless on the free tier, so it's verifiable in seconds: `clawhub install newsflash`, or try the underlying feed directly with `npx newsflash stream -c tech`.

ClawHub link: https://clawhub.ai/zatmonkey/newsflash

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTSt4BDWJCsGjUyLCnbuj5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the `newsflash` skill to the Search & Research documentation.
  * Included a link and description for corroborated real-time news briefings and alerts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->