### PR TITLE
Add skill: sashadiz/posteahora

### DIFF
--- a/README.md
+++ b/README.md
@@ -603,6 +603,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 - [postiz](https://clawskills.sh/skills/nevo-david-postiz) - Schedule social media posts and threads across 28+ platforms.
 - [sequenzy-email-marketing](https://clawhub.ai/polnikale/sequenzy-email-marketing) - Authorized email automation for agents.
 - [tempguru-event-staffing-ordering](https://clawhub.ai/kissmyabs32/tempguru-event-staffing-ordering) - Order W-2 temporary event staff across 345 US/Canada markets.
+- [posteahora](https://clawhub.ai/sashadiz/posteahora) - Schedule and publish social posts across every major network.
 > **[View all 106 skills in Marketing & Sales →](categories/marketing-and-sales.md)**
 </details>
 

--- a/categories/marketing-and-sales.md
+++ b/categories/marketing-and-sales.md
@@ -106,3 +106,4 @@
 - [ldm-openclaw-skill](https://clawhub.ai/live-direct-marketing/ldm-openclaw-skill) - Pre-send deliverability checks for outbound agents.
 - [ldm-openclaw-inbox-mcp-skill](https://clawhub.ai/live-direct-marketing/ldm-openclaw-inbox-mcp-skill) - Paid MCP inbox-placement checks for outbound agents.
 - [tempguru-event-staffing-ordering](https://clawhub.ai/kissmyabs32/tempguru-event-staffing-ordering) - Order W-2 temporary event staff across 345 US/Canada markets.
+- [posteahora](https://clawhub.ai/sashadiz/posteahora) - Schedule and publish social posts across every major network.


### PR DESCRIPTION
Adding **posteahora** to the Marketing & Sales category.

ClawHub link: https://clawhub.ai/sashadiz/posteahora

Schedule and publish social media posts across Instagram, TikTok, YouTube, X (Twitter), Facebook, LinkedIn, Threads, Bluesky and Discord — from your code, terminal, CI, or an AI agent, via CLI, MCP server, or REST API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added the `posteahora` skill to the Marketing & Sales listings.
  * Included a link and description for scheduling and publishing social media posts across major networks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->