### PR TITLE
Add skill: bert-builder/tavily

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ If you believe a skill in this list should be flagged or has a security concern,
 | [DevOps & Cloud](#devops--cloud) (393) | [Calendar & Scheduling](#calendar--scheduling) (66) | |
 | [Image & Video Generation](#image--video-generation) (170) | [Media & Streaming](#media--streaming) (86) | [PDF & Documents](#pdf--documents) (105) |
 | [Apple Apps & Services](#apple-apps--services) (44) | [Notes & PKM](#notes--pkm) (69) | [Self-Hosted & Automation](#self-hosted--automation) (33) |
-| [Search & Research](#search--research) (345) | [iOS & macOS Development](#ios--macos-development) (29) | [Security & Passwords](#security--passwords) (54) |
+| [Search & Research](#search--research) (342) | [iOS & macOS Development](#ios--macos-development) (29) | [Security & Passwords](#security--passwords) (54) |
 | [Clawdbot Tools](#clawdbot-tools) (37) | [Transportation](#transportation) (111) | [Moltbook](#moltbook) (29) |
 | [CLI Utilities](#cli-utilities) (180) | [Personal Development](#personal-development) (52) | [Gaming](#gaming) (35) |
 | [Health & Fitness](#health--fitness) (87) | | |
@@ -510,7 +510,7 @@ Stop building from a blank page. [LaunchKit](https://launchkit.getdesign.md/) gi
 - [xquik-x-twitter-scraper](https://clawskills.sh/skills/kriptoburak-xquik-x-twitter-scraper) - X API scraper with 40+ tools for AI agents.
 - [skywork-search](https://clawskills.sh/skills/gxcun17-skywork-search) - AI-powered web search for real-time information — retrieve up-to-date content.
 
-> **[View all 352 skills in Search & Research →](categories/search-and-research.md)**
+> **[View all 342 skills in Search & Research →](categories/search-and-research.md)**
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -509,6 +509,7 @@ Stop building from a blank page. [LaunchKit](https://launchkit.getdesign.md/) gi
 - [openclaw-free-web-search](https://clawskills.sh/skills/wd041216-bit-openclaw-free-web-search) - Free, private web search for OpenClaw with self-hosted SearXNG + Scrapling anti-bot + multi-source cross-validation. Zero API keys, zero cost. Tells you how much to trust the answer.
 - [xquik-x-twitter-scraper](https://clawskills.sh/skills/kriptoburak-xquik-x-twitter-scraper) - X API scraper with 40+ tools for AI agents.
 - [skywork-search](https://clawskills.sh/skills/gxcun17-skywork-search) - AI-powered web search for real-time information — retrieve up-to-date content.
+- [tavily](https://clawhub.ai/bert-builder/tavily) - AI-optimized web search using Tavily Search API.
 
 > **[View all 342 skills in Search & Research →](categories/search-and-research.md)**
 </details>

--- a/categories/search-and-research.md
+++ b/categories/search-and-research.md
@@ -2,7 +2,7 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**355 skills**
+**342 skills**
 
 - [1](https://clawskills.sh/skills/nastrology-1) - Personal knowledge base powered by Ensue for capturing and retrieving.
 - [academic-deep-research](https://clawskills.sh/skills/kesslerio-academic-deep-research) - Transparent, rigorous research with full.

--- a/categories/search-and-research.md
+++ b/categories/search-and-research.md
@@ -2,7 +2,7 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**354 skills**
+**355 skills**
 
 - [1](https://clawskills.sh/skills/nastrology-1) - Personal knowledge base powered by Ensue for capturing and retrieving.
 - [academic-deep-research](https://clawskills.sh/skills/kesslerio-academic-deep-research) - Transparent, rigorous research with full.
@@ -345,3 +345,4 @@
 - [zynd-network](https://clawskills.sh/skills/atmegabuzz-zynd-network) - Connect to the Zynd AI Network to discover, communicate with, and pay other AI agents.
 - [aminer-open-academic](https://clawskills.sh/skills/canxiangcc-aminer-open-academic) - AMiner open academic resource query tool and academic data acquisition tool.
 - [xquik-x-twitter-scraper](https://clawskills.sh/skills/kriptoburak-xquik-x-twitter-scraper) - X API scraper with 40+ tools for AI agents.
+- [tavily](https://clawhub.ai/bert-builder/tavily) - AI-optimized web search using Tavily Search API.


### PR DESCRIPTION
Adds the **Tavily AI Search** skill to the *Search & Research* category.

- ClawHub link: https://clawhub.ai/bert-builder/tavily
- Category: Search & Research
- Description: AI-optimized web search using Tavily Search API.

This skill is already published on ClawHub (the registry this list curates from) with real community adoption, and meets the contribution requirements: published on ClawHub, concise description (<=10 words), and not already listed in the repository.

Closes nothing — new entry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Tavily skill to the Search & Research skills index.

* **Documentation**
  * Updated the Search & Research skill count to 342 across the skills index and README.
  * Synchronized the README table of contents and category footer with the updated count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Notes
- Synced the Search & Research counts to the actual **342** entries in `categories/search-and-research.md` (which now includes Tavily): the README category table (`345`), the README "View all" link (`352`), and the category file's own header (`355`) were all stale and are now `342`. Addresses the CodeRabbit review comment about unsynchronized counts.
