### PR TITLE
Add skill: grubbylee/skill-navigator

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ Stop building from a blank page. [LaunchKit](https://launchkit.getdesign.md/) gi
 - [skywork-music-maker](https://clawskills.sh/skills/gxcun17-skywork-music-maker) - Create professional music with Mureka AI.
 - [before-you-build](https://clawhub.ai/bin1874/before-you-build) - Review product risk before building.
 - [ditto-profile](https://clawhub.ai/ohad6k/ditto-profile) - Load your mined personal profile so agents work like you.
+- [skill-navigator](https://clawhub.ai/grubbylee/skills/skill-navigator) - Recommends the right installed local Agent Skill.
 
 > **[View all 1200 skills in Coding Agents & IDEs →](categories/coding-agents-and-ides.md)**
 </details>


### PR DESCRIPTION
## Summary

Add `grubbylee/skill-navigator` to the Coding Agents & IDEs category.

ClawHub link:
https://clawhub.ai/grubbylee/skills/skill-navigator

## Notes

- Published on ClawHub as `grubbylee/skill-navigator`
- Latest version: 0.1.5
- ClawHub moderation status: CLEAN
- Purpose: recommend which already-installed local Agent Skill should handle a user task

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added ditto-profile and skill-navigator to the Coding Agents & IDEs skill list.
  * Included ClawHub links and descriptions for both skills.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->