### PR TITLE
Add skill: dxshelley/obsidian-cli-plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -775,6 +775,7 @@ Stop building from a blank page. [LaunchKit](https://launchkit.getdesign.md/) gi
 - [continuity](https://clawskills.sh/skills/riley-coyote-continuity) - Asynchronous reflection and memory integration for genuine AI.
 - [continuity-framework](https://clawskills.sh/skills/riley-coyote-continuity-framework) - Asynchronous reflection and memory integration.
 - [ai-footprints](https://clawhub.ai/Piccolo123/ai-footprints) - Cross-platform bookmark manager with AI categorization, shared collections, and Agent API access.
+- [obsidian-cli-plugins](https://clawhub.ai/dxshelley/obsidian-cli-plugins) - Automate Obsidian vaults, tasks, journals, and Git sync.
 
 > **[View all 69 skills in Notes & PKM →](categories/notes-and-pkm.md)**
 </details>


### PR DESCRIPTION
## What changed

Added `dxshelley/obsidian-cli-plugins` to the Notes & PKM section.

## Why

The skill is publicly available on ClawHub and provides Obsidian vault automation for tasks, journals, and Git sync.

## ClawHub

https://clawhub.ai/dxshelley/skills/obsidian-cli-plugins

## Validation

- Verified the ClawHub link returns HTTP 200.
- Ran `git diff --check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the `obsidian-cli-plugins` skill to the Notes & PKM category.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->