### PR TITLE
Update skill: drakulavich/kesha-voice-kit

### DIFF
--- a/categories/speech-and-transcription.md
+++ b/categories/speech-and-transcription.md
@@ -38,7 +38,7 @@
 - [her-voice](https://clawskills.sh/skills/matusvojtek-her-voice) - Give your agent a voice.
 - [inworld-tts](https://clawskills.sh/skills/gugic-inworld-tts) - Text-to-speech via Inworld.ai API.
 - [jarvis-voice](https://clawskills.sh/skills/globalcaos-jarvis-voice) - Metallic AI voice persona with TTS and visual transcript styling.
-- [kesha-voice-kit](https://clawskills.sh/skills/drakulavich-kesha-voice-kit) - Local STT + TTS with Russian, offline on Apple Silicon.
+- [kesha-voice-kit](https://clawskills.sh/skills/drakulavich-kesha-voice-kit) - Offline speech-to-text in 25 languages, TTS in 9, speaker diarization.
 - [kokoro-tts](https://clawskills.sh/skills/edkief-kokoro-tts) - Generate spoken audio from text using the local Kokoro TTS engine.
 - [lnbits](https://clawskills.sh/skills/talvasconcelos-lnbits) - Manage LNbits Lightning Wallet (Balance, Pay, Invoice)
 - [lnbits-with-qrcode](https://clawskills.sh/skills/jamestsetsekas-lnbits-with-qrcode) - Manage LNbits Lightning Wallet (Balance, Pay, Invoice)


### PR DESCRIPTION
ClawHub link: https://clawhub.ai/drakulavich/skills/kesha-voice-kit

This is an update to an existing entry, not a new addition.

The current description in `categories/speech-and-transcription.md` reads:

> Local STT + TTS with Russian, offline on Apple Silicon.

It only names Russian, which undersells what the skill does and makes it hard to find for the languages it actually covers. Updated to:

> Offline speech-to-text in 25 languages, TTS in 9, speaker diarization.

All three claims are current: STT covers 25 languages via NVIDIA Parakeet TDT, TTS covers 9 (Kokoro + Vosk-TTS), and speaker diarization landed for darwin-arm64. 10 words, within the guideline.

Skill is published on ClawHub with a passing security audit. One line changed; alphabetical position unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the `kesha-voice-kit` description to highlight offline speech-to-text support in 25 languages, text-to-speech in 9 languages, and speaker diarization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->