### PR TITLE
Add Open Index to ecosystem tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ Include the ClawHub link for your skill (e.g. `https://clawhub.ai/steipete/slack
 
 ## OpenClaw Ecosystem Tools
 
+### 🧠 Memory & Context
+
+[Open Index](https://github.com/DrDroidLab/open-index) gives domain-specific OpenClaw agents a structured, searchable context graph with read/write MCP access and a portable [setup skill](https://github.com/DrDroidLab/open-index/blob/main/skills/setup-open-index/SKILL.md).
+
 ### 🔌 Connecting to External Services
 
 OpenClaw agents can interact with external services like GitHub, Slack, Gmail, and more. You can build integrations yourself with Skills or Plugins, or use a managed service to handle auth, token refresh, and permissions across all your connections.


### PR DESCRIPTION
## Summary

Add Open Index to the OpenClaw Ecosystem Tools area under Memory & Context.

Open Index ships a portable OpenClaw-compatible setup skill, but it is not currently listed on ClawHub, so this PR does not add it to the registry-sourced skill catalog.

Project: https://github.com/DrDroidLab/open-index

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a “Memory & Context” section highlighting Open Index.
  * Included links to the Open Index repository and setup guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->