### PR TITLE
Add scvd-tab to Productivity & Tasks

### DIFF
--- a/categories/productivity-and-tasks.md
+++ b/categories/productivity-and-tasks.md
@@ -212,3 +212,4 @@
 - [blog-studio](https://clawhub.ai/amrree/blog-studio) - Standalone CMS for GitHub Pages Jekyll blogs — browse, edit, create, and deploy with one click.
 - [FlowBoard](https://clawhub.ai/rasimme/plugins/flowboard) - Persistent per-project context and Kanban for agents.
 - [sol-scribe](https://clawhub.ai/amrree/sol-scribe) - Book writing companion for long-form creative projects — chapter planning, narrative consistency, and AI-assisted drafting.
+- [scvd-tab](https://clawhub.ai/seancrecord/scvd-tab) - Track tool spending, trial conversions, and unused subscriptions for AI agents.


### PR DESCRIPTION
ClawHub: https://clawhub.ai/seancrecord/scvd-tab

scvd-tab tracks what an agent spends on tools and subscriptions — trials converting, burn rate, unused-tool detection.

Entry added to `categories/productivity-and-tasks.md`, appended at end per CONTRIBUTING.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the `scvd-tab` skill to the Productivity & Tasks category.
  * Updated the category’s listed skill count from 207 to 208.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->