### PR TITLE
Add skill: programmingwtf/repo-standardizer

### DIFF
--- a/categories/git-and-github.md
+++ b/categories/git-and-github.md
@@ -2,7 +2,7 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**159 skills**
+**160 skills**
 
 - [agent-commons](https://clawskills.sh/skills/zanblayde-agent-commons) - Consult, commit, extend, and challenge reasoning chains.
 - [agent-team-orchestration](https://clawskills.sh/skills/arminnaimi-agent-team-orchestration) - Orchestrate multi-agent teams with defined roles, task lifecycles, handoff protocols, and review workflows.

--- a/categories/git-and-github.md
+++ b/categories/git-and-github.md
@@ -159,3 +159,4 @@
 - [xpr-structured-data](https://clawskills.sh/skills/paulgnz-xpr-structured-data) - CSV parsing, JSON-to-CSV conversion, and SVG chart generation.
 - [zai-tts](https://clawskills.sh/skills/al-one-zai-tts) - Text-to-speech conversion using GLM-TTS service via the `uvx zai-tts` command for generating audio from text.
 - [zhipu-tts](https://clawskills.sh/skills/franklu0819-lang-zhipu-tts) - Text-to-speech conversion using Zhipu AI (BigModel) GLM-TTS model.
+- [repo-standardizer](https://clawhub.ai/programmingwtf/repo-standardizer) - Polish any GitHub repo surface: labels, issue forms, PR templates, CI, rulesets, docs.


### PR DESCRIPTION
ClawHub link: https://clawhub.ai/programmingwtf/repo-standardizer

repo-standardizer is the only repo-**write** skill on ClawHub — every other GitHub-repo skill reads/analyzes. It polishes a repository's surface (label taxonomy with rating tiers, issue forms, PR template, CI workflows, rulesets, docs) idempotently, auth-first, and never touches code logic.

- Published on ClawHub: yes (@programmingwtf/repo-standardizer, v1.0.0)
- SKILL.md documentation: yes
- Security status: clean (Moderate CLEAN — no suspicious patterns)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `repo-standardizer` skill to the Git & GitHub catalog.
  * Updated the catalog to include 160 listed skills.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->