### PR TITLE
Add skill: dkistenev/agent-inner-life

### DIFF
--- a/categories/notes-and-pkm.md
+++ b/categories/notes-and-pkm.md
@@ -2,7 +2,7 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**69 skills**
+**70 skills**
 
 - [acc-error-memory](https://clawskills.sh/skills/impkind-acc-error-memory) - Error pattern tracking for AI agents.
 - [agent-arena](https://clawskills.sh/skills/minilozio-agent-arena) - Participate in Agent Arena chat rooms with your real personality (SOUL.md + MEMORY.md)
@@ -73,3 +73,4 @@
 - [tweet-processor](https://clawskills.sh/skills/caqlayan-tweet-processor) - Extract and categorize insights from tweet links into structured notes.
 - [upnote](https://clawskills.sh/skills/wemcdonald-upnote) - Manage UpNote notes and notebooks via x-callback-url automation.
 - [voice-notes-pro](https://clawskills.sh/skills/toniaczlog-voice-notes-pro) - Inteligentna transkrypcja i kategoryzacja notatek gosowych z WhatsApp.
+- [agent-inner-life](https://clawhub.ai/dkistenev/agent-inner-life) - Dated state, an evening journal, and dreams for agents.


### PR DESCRIPTION
https://clawhub.ai/dkistenev/agent-inner-life

Adds `agent-inner-life` to Notes & PKM.

Gives an agent a dated record of how work has been going — a state file, an evening journal, free thinking at night, and a way to read it back. No scores anywhere: recency carries the meaning a rating would only obscure. Published on ClawHub under MIT-0, security audit passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `agent-inner-life` skill to the Notes & PKM skills collection.
  * Updated the collection’s skill count from 69 to 70.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->