### PR TITLE
Add skill: conorbronsdon/avoid-ai-writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,6 +507,7 @@ Stop building from a blank page. [LaunchKit](https://launchkit.getdesign.md/) gi
 - [skywork-search](https://clawskills.sh/skills/gxcun17-skywork-search) - AI-powered web search for real-time information — retrieve up-to-date content.
 - [tavily](https://clawhub.ai/bert-builder/tavily) - AI-optimized web search using Tavily Search API.
 - [newsflash](https://clawhub.ai/zatmonkey/newsflash) - Corroborated real-time news briefings and alerts for agents.
+- [openclaw-search-skills](https://clawhub.ai/blessonism/skills/openclaw-search-skills) - Multi-source deep search with structured research reports.
 
 > **[View all 342 skills in Search & Research →](categories/search-and-research.md)**
 </details>
@@ -679,6 +680,8 @@ Stop building from a blank page. [LaunchKit](https://launchkit.getdesign.md/) gi
 - [agent-sentinel](https://clawskills.sh/skills/jimmystacks-agent-sentinel) - The operational circuit breaker for this agent.
 
 - [agentbase](https://clawskills.sh/skills/revmischa-agentbase) - Shared knowledge base for AI agents via MCP.
+- [avoid-ai-writing](https://clawhub.ai/conorbronsdon/skills/avoid-ai-writing) - Audit and rewrite text to remove AI writing patterns.
+- [model-hierarchy-skill](https://clawhub.ai/zscole/skills/model-hierarchy-skill) - Route tasks to cheaper models based on complexity.
 > **[View all 185 skills in AI & LLMs →](categories/ai-and-llms.md)**
 </details>
 


### PR DESCRIPTION
Adds three ClawHub-published skills to the README:

**AI & LLMs**
- [avoid-ai-writing](https://clawhub.ai/conorbronsdon/skills/avoid-ai-writing) - Audit and rewrite text to remove AI writing patterns. This is my skill (3.2k stars on GitHub, published on ClawHub at the link above). I'm disclosing that affiliation directly per your self-promo expectations.
- [model-hierarchy-skill](https://clawhub.ai/zscole/skills/model-hierarchy-skill) - Route tasks to cheaper models based on complexity. Not mine; 344 stars on GitHub.

**Search & Research**
- [openclaw-search-skills](https://clawhub.ai/blessonism/skills/openclaw-search-skills) - Multi-source deep search with structured research reports. Not mine; 436 stars on GitHub.

Notes:
- All three are verified published on ClawHub and verified absent from the README before this change.
- Per CONTRIBUTING guidance on multi-skill authors, I linked one representative entry for myself rather than listing all of my skills individually.
- Descriptions kept under 10 words, matching existing entry format.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added three skills to the README:
    * `openclaw-search-skills` under Search & Research
    * `avoid-ai-writing` under AI & LLMs
    * `model-hierarchy-skill` under AI & LLMs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->