### PR TITLE
Add mnemosyne: zero-dependency cognitive memory engine for agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,6 +540,7 @@ Stop building from a blank page. [LaunchKit](https://launchkit.getdesign.md/) gi
 - [clawdirect](https://clawskills.sh/skills/napoleond-clawdirect) - Interact with ClawDirect, a directory of social web experiences.
 - [clawdirect-dev](https://clawskills.sh/skills/napoleond-clawdirect-dev) - Build agent-facing web experiences with ATXP-based.
 - [honcho-setup](https://clawskills.sh/skills/ajspig-honcho-setup) - Persistent cross-session memory via Honcho.
+- [mnemosyne](https://github.com/ElonAug7/Mnemosyne-agentmemory-engine-openclaw-hermes) - Zero-dependency cognitive memory engine for agents: compound-cue theory retrieval (5.2x benchmark gains), pure Markdown storage, zero API keys.
 
 > **[View all 37 skills in Clawdbot Tools →](categories/clawdbot-tools.md)**
 </details>


### PR DESCRIPTION
## What

Adds **mnemosyne** to the **Clawdbot Tools** section — a zero-dependency cognitive memory engine that gives OpenClaw agents persistent, human-like memory.

## Why it belongs here

- **Zero dependencies** — no LLM API calls, no vector database, no embedding model. Pure Node.js + plain Markdown files
- **Cognitive-science-based retrieval** — compound-cue theory (Raaijmakers & Shiffrin, 1981) with time decay, testing effect, Zeigarnik effect, superseded-memory demotion
- **Real benchmark results** — Memory-Native Evaluation (80 queries, 11 systems): nDCG@10 **0.238**, 5.2× over the previous version, beating raw BM25 (0.185) and all embedding-based systems — with zero embeddings
- **Data sovereignty** — every memory is a readable Markdown file on the user's machine; nothing leaves the host
- **Mature** — 14 versions in active development, 8/8 test suite, used in production with OpenClaw and Hermes

Repo: https://github.com/ElonAug7/Mnemosyne-agentmemory-engine-openclaw-hermes

One-line entry (follows the list format):

```
- [mnemosyne](https://github.com/ElonAug7/Mnemosyne-agentmemory-engine-openclaw-hermes) - Zero-dependency cognitive memory engine for agents: compound-cue theory retrieval (5.2x benchmark gains), pure Markdown storage, zero API keys.
```

Happy to adjust wording or placement per your curation guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the Mnemosyne skill to the Clawdbot Tools section, including a link to its repository and a brief description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->