### PR TITLE
Add skill: ustczz/ai-calls-china-phone

### DIFF
--- a/categories/communication.md
+++ b/categories/communication.md
@@ -2,7 +2,7 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**146 skills**
+**145 skills**
 
 - [aa](https://clawskills.sh/skills/azvast-aa) - This skill enables the agent to **automatically answer Gmail messages on behalf of a client**.
 - [agent-mail](https://clawskills.sh/skills/rimelucci-agent-mail) - Email inbox for AI agents.

--- a/categories/communication.md
+++ b/categories/communication.md
@@ -148,3 +148,4 @@
 - [lobstermail-agent-email](https://clawskills.sh/skills/samuelchenardlovesboards-lobstermail-agent-email) - Email for AI agents. No API keys, no signup.
 - [sol-email](https://clawhub.ai/amrree/sol-email) - Read and send emails via himalaya (Maildir) and SMTP. Real inbox, real replies.
 - [atomicmail](https://clawhub.ai/atomicmail/atomicmail) - Agent-owned @atomicmail.ai inbox over JMAP. PoW signup, no API keys.
+- [ai-calls-china-phone](https://clawhub.ai/ustczz/skills/ai-calls-china-phone) - AI phone calls and inbound reception for mainland China.


### PR DESCRIPTION
Adds the established ClawCall AI phone skill for mainland China to Communication.

- ClawHub: https://clawhub.ai/ustczz/skills/ai-calls-china-phone
- Current release: v1.0.14
- Community usage: 1,587 downloads and 47 installs at submission time
- ClawHub security audit: Pass
- Supports confirmed single-number outbound calls, inbound reception setup, and transcripts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Communication category entry for AI phone calls and inbound reception in mainland China.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->