### PR TITLE
Add memory-shield (agent memory poisoning defense)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ OpenClaw is a locally-running AI assistant that operates directly on your machin
 
 Skills in this list are sourced from ClawHub (OpenClaw's public skills registry) and categorized for easier discovery.
 
-- [memory-shield](https://github.com/vnbochkarev-netizen/memory-shield) - Defend agent memory against prompt-injection poisoning: snapshots before compaction, poisoned-content quarantine, masked secrets, diff audit (MIT, zero deps)
+- [memory-shield](https://clawhub.ai/vnbochkarev-netizen/memory-shield) - Defend agent memory against prompt-injection poisoning: snapshots before compaction, poisoned-content quarantine, masked secrets, diff audit (MIT, zero deps)
 ### Installation
 
 #### OpenClaw CLI

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ OpenClaw is a locally-running AI assistant that operates directly on your machin
 
 Skills in this list are sourced from ClawHub (OpenClaw's public skills registry) and categorized for easier discovery.
 
+- [memory-shield](https://github.com/vnbochkarev-netizen/memory-shield) - Defend agent memory against prompt-injection poisoning: snapshots before compaction, poisoned-content quarantine, masked secrets, diff audit (MIT, zero deps)
 ### Installation
 
 #### OpenClaw CLI


### PR DESCRIPTION
Adds [memory-shield](https://github.com/vnbochkarev-netizen/memory-shield) - open-source (MIT, zero-deps) agent-memory poisoning defense: snapshots before compaction, quarantine, masked secrets. Works with Claude Code / OpenClaw. CI: SkillQA grade A on every PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the `memory-shield` entry in the skills index.
  * Changed its link from the GitHub repository to the corresponding ClawHub page while preserving the existing name and description.
  * The entry continues to provide information about memory-protection capabilities, licensing, and dependency status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->