### PR TITLE
Add skill: vivekchand/clawmetry

### DIFF
--- a/categories/devops-and-cloud.md
+++ b/categories/devops-and-cloud.md
@@ -2,7 +2,7 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**392 skills**
+**393 skills**
 
 - [0x0-messenger](https://clawskills.sh/skills/eijiac24-0x0-messenger) - Send and receive P2P messages using disposable numbers and PINs.
 - [12306](https://clawskills.sh/skills/kirorab-12306) - Query China Railway 12306 for train schedules, remaining tickets, and station info.
@@ -379,3 +379,4 @@
 - [xpoz-social-search](https://clawskills.sh/skills/atyachin-xpoz-social-search) - Search Twitter, Instagram, and Reddit posts in real time.
 - [ztp](https://clawskills.sh/skills/thomastrumpp-ztp) - A mandatory security audit skill for validating new code, skills, and MCP servers against the SEP-2026 Zero Trust.
 - [zyfai-sdk](https://clawskills.sh/skills/pauldefi-zyfai-sdk) - Earn yield on any Ethereum wallet on Base, Arbitrum, and Plasma.
+- [clawmetry](https://clawhub.ai/vivekchand/clawmetry) - Local observability dashboard for OpenClaw sessions, tokens, and costs.


### PR DESCRIPTION
ClawHub link: https://clawhub.ai/vivekchand/clawmetry

**What it is.** ClawMetry is a self-hosted, local-first observability dashboard and kill switch for AI agent runtimes, with OpenClaw as its first and primary runtime. It reads the session logs OpenClaw already writes on disk (`~/.openclaw/agents/main/sessions/*.jsonl`, plus the gateway WebSocket), so there is no SDK to install and nothing sits in the request path. It shows sessions, transcripts, tool calls, tokens and cache-aware cost per session and per model, plus crons, memory files and system health. Install is `pip install clawmetry && clawmetry`; the ClawHub skill wraps the same tool for OpenClaw. Source: https://github.com/vivekchand/clawmetry (MIT, open-core). Homepage: https://clawmetry.com

**Why DevOps & Cloud.** It is an operations tool for running OpenClaw day to day, alongside existing entries such as `agent-metrics-osiris` and `agentic-devops`. Added at the end of the category per CONTRIBUTING and bumped the category count (392 to 393), matching how #554 was merged. The ClawHub listing has a passing security audit. Pricing, stated plainly: OpenClaw (and NemoClaw) observability is free in the open-source app; observing other runtimes (Claude Code, Codex, Cursor, and so on) needs ClawMetry Cloud or a self-hosted Pro license. Optional cloud sync is off by default and E2E encrypted when enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01Rt5fq2BWxieLpR69MAbwjr


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Clawmetry skill to the DevOps & Cloud skills list.
  * Updated the listed skill count from 392 to 393.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->