### PR TITLE
Add skill: xizhuomengcontin/orca-replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ Stop building from a blank page. [LaunchKit](https://launchkit.getdesign.md/) gi
 - [ditto-profile](https://clawhub.ai/ohad6k/ditto-profile) - Load your mined personal profile so agents work like you.
 - [skill-navigator](https://clawhub.ai/grubbylee/skills/skill-navigator) - Recommends the right installed local Agent Skill.
 - [emulo](https://clawhub.ai/ohad6k/emulo) - Load your mined personal profile so agents work like you.
+- [orca-replay](https://clawhub.ai/xizhuomengcontin/orca-replay) - Replay and debug past coding-agent runs from their recordings.
 
 > **[View all 1200 skills in Coding Agents & IDEs →](categories/coding-agents-and-ides.md)**
 </details>


### PR DESCRIPTION
**ClawHub link:** https://clawhub.ai/xizhuomengcontin/orca-replay

One line added to the end of **Coding Agents & IDEs**.

```
- [orca-replay](https://clawhub.ai/xizhuomengcontin/orca-replay) - Replay and debug past coding-agent runs from their recordings.
```

## Against the requirements

- **Published on ClawHub** — yes, v1.0.0, self-published, live.
- **ClawHub verification passing** — `clawhub skill verify orca-replay` returns `"decision": "pass"`, `"reasons": []`.
- **Security status clean** — `"passed": true`, `"verdict": "benign"`, `"confidence": "high"`; static scan `"clean"` with no reason codes. ClawHub's own summary of it: *"a disclosed replay and analysis helper for recorded agent runs, with important replay and data-sharing risks called out in its instructions."*
- **Has documentation** — `SKILL.md`, plus the upstream repo at [Continuum-AI-Corp/OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay) (Apache-2.0).
- **Description ≤ 10 words** — 9.
- **Not crypto / finance** — no.
- **Not a duplicate** — searched the README for `orca-replay`: 0 hits.
- **Real community usage** — ⚠️ **not yet, and I would rather say so than let you find it.** The skill is new. If your answer is "come back when it has users", that is a fair call and I will not re-open or re-submit.

## What it does, since OpenClaw is a specific case

OrcaReplay records an agent run below the harness and can replay it offline or fork it from a checkpoint onto another model. The skill is the layer that tells an agent to answer "why did you delete that file yesterday" from the recording instead of reconstructing it from context, and to keep the causal graph's `recorded` and `inferred` labels apart when it does.

OpenClaw is one of the harnesses it records, and an awkward one: it does not do the coding itself, it runs Claude Code, Codex or opencode as child processes, so one session carries two kinds of model traffic. Both are captured — the gateway's own calls through a fetch hook, the spawned agents through inherited environment variables.

The skill is deliberately explicit about what replay does *not* isolate: the agent process runs live, so a recorded run's shell commands execute again, and `orca_compare` uploads the run's files and conversation prefix to every provider it is given. Those are gated behind separate approvals rather than mentioned in passing — which is what ClawHub's scanner picked up on above.

Disclosure: I work on OrcaReplay.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the `orca-replay` skill to the “Coding Agents & IDEs” list.
  * Included a link and description for replaying and debugging recorded coding-agent runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->