### PR TITLE
Add skill: assistantmail/assistant-mail

### DIFF
--- a/categories/communication.md
+++ b/categories/communication.md
@@ -2,7 +2,7 @@
 
 [← Back to main list](../README.md#table-of-contents)
 
-**145 skills**
+**146 skills**
 
 - [aa](https://clawskills.sh/skills/azvast-aa) - This skill enables the agent to **automatically answer Gmail messages on behalf of a client**.
 - [agent-mail](https://clawskills.sh/skills/rimelucci-agent-mail) - Email inbox for AI agents.

--- a/categories/communication.md
+++ b/categories/communication.md
@@ -149,3 +149,4 @@
 - [sol-email](https://clawhub.ai/amrree/sol-email) - Read and send emails via himalaya (Maildir) and SMTP. Real inbox, real replies.
 - [atomicmail](https://clawhub.ai/atomicmail/atomicmail) - Agent-owned @atomicmail.ai inbox over JMAP. PoW signup, no API keys.
 - [ai-calls-china-phone](https://clawhub.ai/ustczz/skills/ai-calls-china-phone) - AI phone calls and inbound reception for mainland China.
+- [assistant-mail](https://clawhub.ai/assistantmail/skills/assistant-mail) - Allowlist/consent agent email for small-team operators.


### PR DESCRIPTION
## Summary

Adds **assistant-mail** to Communication.

Beachhead: personal and small-team OpenClaw/Hermes operators needing recipient allowlist and consent before send. Not for cold-outbound fleets. Not an official OpenClaw endorsement.

## ClawHub

https://clawhub.ai/assistantmail/skills/assistant-mail

Also related MCP: https://github.com/AssistantMail/assistantmail-mcp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `assistant-mail` communication skill.
  * Updated the communication skills count from 145 to 146, reflecting the newly available skill.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->