### PR TITLE
Add skill: anil-matcha/muapi-platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,6 +551,7 @@ Stop building from a blank page. [LaunchKit](https://launchkit.getdesign.md/) gi
 - [camsnap](https://clawskills.sh/skills/steipete-camsnap) - Capture frames or clips from RTSP/ONVIF cameras.
 - [canvas-lms](https://clawskills.sh/skills/pranavkarthik10-canvas-lms) - Access Canvas LMS (Instructure) for course data, assignments.
 - [captcha-ai](https://clawskills.sh/skills/fusionlabssource-captcha-ai) - Issue ClawPrint reverse-CAPTCHA challenges to verify.
+- [muapi-platform](https://clawhub.ai/anil-matcha/muapi-platform) - Configure MuAPI keys, test connectivity, and poll async jobs.
 
 > **[View all 180 skills in CLI Utilities →](categories/cli-utilities.md)**
 </details>

--- a/categories/cli-utilities.md
+++ b/categories/cli-utilities.md
@@ -174,3 +174,4 @@
 - [wind-site](https://clawskills.sh/skills/qrost-wind-site) - Wind rose, wind speed/direction at a site; supports site and urban wind assessment (data only; detailed CFD.
 - [wol-sleep-pc](https://clawskills.sh/skills/oblivisheee-wol-sleep-pc) - Send Wake-on-LAN (magic packet) and Sleep-on-LAN (inverted MAC) packets for a specific PC.
 - [xiaohongshu-automation](https://clawskills.sh/skills/dingkwang-xiaohongshu-automation) - A complete automation suite for Xiaohongshu (Little Red Book)
+- [muapi-platform](https://clawhub.ai/anil-matcha/muapi-platform) - Configure MuAPI keys, test connectivity, and poll async jobs.


### PR DESCRIPTION
## Summary

- Add the published `muapi-platform` skill to the CLI Utilities category.
- Link directly to its ClawHub listing for installation and verification.

## Verification

- ClawHub listing: https://clawhub.ai/anil-matcha/muapi-platform
- MuAPI API documentation: https://muapi.ai/docs/api-reference
- The catalog description is concise and describes the skill's key-management, connectivity, and polling helpers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the MuAPI Platform skill to the CLI Utilities catalog.
  - Included guidance for configuring MuAPI keys, testing connectivity, and polling asynchronous jobs.
  - Added a link to the skill’s ClawHub page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->