### PR TITLE
Add Skill Injection Scanner + Context Compactor to Recommended tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ Before installing or using any Agent Skill, review potential security risks and 
 
 - [Snyk Skill Security Scanner](https://github.com/snyk/agent-scan)
 - [Agent Trust Hub](https://ai.gendigital.com/agent-trust-hub)
+- [Skill Injection Scanner](https://github.com/vnbochkarev-netizen/skill-injection-scanner) - scan installed OpenClaw skills for prompt-injection patterns (EN/RU, 19 rules) before first use
+- [Context Compactor CLI](https://github.com/vnbochkarev-netizen/context-compactor) - condense long OpenClaw sessions into handoff memos; credential values auto-redacted
   
 > Agent skills can include prompt injections, tool poisoning, hidden malware payloads, or unsafe data handling patterns. Always review the source code before installing and use skills at your own discretion.
 


### PR DESCRIPTION
Adding two local-first security tools to the "Recommended tools" block under Security Notice — both fit the OpenClaw workflow:

- **[Skill Injection Scanner](https://github.com/vnbochkarev-netizen/skill-injection-scanner)** — scan installed skills for prompt-injection / hidden instructions (EN+RU, 19 rules) before first use. Complements Snyk/Agent Trust Hub as the "scan what you already installed" step: `python3 scanner.py --skills ~/.openclaw/skills`. Also on ClawHub (`skill-injection-scanner`) and npm.
- **[Context Compactor CLI](https://github.com/vnbochkarev-netizen/context-compactor)** — condense long OpenClaw sessions into a handoff memo before compaction; credential values auto-redacted. On ClawHub as `context-compactor-cli`, npm `@vibo-dev/context-compactor`.

MIT, zero dependencies, self-tested. Happy to adjust wording/placement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added Skill Injection Scanner to the recommended security tools list.
  - Added Context Compactor CLI, which condenses long sessions into handoff memos with automatic credential-value redaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->